### PR TITLE
Issue #55: OpenWeather API キー対応

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,8 @@
 # MapTiler API Key
-NEXT_PUBLIC_MAPTILER_KEY=
+NEXT_PUBLIC_MAPTILER_KEY=ancy6ApYb8XIMXDzRMLj
+
+# OpenWeather API Key
+NEXT_PUBLIC_OPENWEATHER_KEY=0960e7d3f5202aa7424e3ba24a6a4e8e
 
 # Map Styles
 NEXT_PUBLIC_MAP_STYLE_LIGHT=https://api.maptiler.com/maps/streets-v2/style.json

--- a/docs/api-specifications.md
+++ b/docs/api-specifications.md
@@ -661,6 +661,21 @@ export function MapViewClient({ center, zoom }: MapViewClientProps) {
 }
 ```
 
+### 4.7 OpenWeatherMap Precipitation Tiles
+
+#### 基本情報
+
+- **ベース URL**: `https://tile.openweathermap.org`
+- **用途**: 降水レイヤーの表示
+- **認証**: API キー必須（`NEXT_PUBLIC_OPENWEATHER_KEY`）
+- **データ形式**: Raster Tiles（PNG）
+
+#### タイル URL 例
+
+```
+https://tile.openweathermap.org/map/precipitation_new/{z}/{x}/{y}.png?appid={OPENWEATHER_KEY}
+```
+
 ---
 
 ## 5. API エラーハンドリング戦略

--- a/docs/development-checklist.md
+++ b/docs/development-checklist.md
@@ -159,6 +159,9 @@ git push -u origin main
   # MapTiler API Key
   NEXT_PUBLIC_MAPTILER_KEY=
 
+  # OpenWeather API Key
+  NEXT_PUBLIC_OPENWEATHER_KEY=
+
   # Map Styles
   NEXT_PUBLIC_MAP_STYLE_LIGHT=https://api.maptiler.com/maps/streets-v2/style.json
   NEXT_PUBLIC_MAP_STYLE_DARK=https://api.maptiler.com/maps/streets-v2-dark/style.json
@@ -177,6 +180,7 @@ git push -u origin main
 
   ```bash
   NEXT_PUBLIC_MAPTILER_KEY=your_dev_key_here
+  NEXT_PUBLIC_OPENWEATHER_KEY=your_dev_key_here
   NEXT_PUBLIC_MAP_STYLE_LIGHT=https://api.maptiler.com/maps/streets-v2/style.json
   NEXT_PUBLIC_MAP_STYLE_DARK=https://api.maptiler.com/maps/streets-v2-dark/style.json
   NEXT_PUBLIC_DEFAULT_CITY=tokyo
@@ -187,6 +191,7 @@ git push -u origin main
 
   ```bash
   NEXT_PUBLIC_MAPTILER_KEY=your_prod_key_here
+  NEXT_PUBLIC_OPENWEATHER_KEY=your_prod_key_here
   NEXT_PUBLIC_MAP_STYLE_LIGHT=https://api.maptiler.com/maps/streets-v2/style.json
   NEXT_PUBLIC_MAP_STYLE_DARK=https://api.maptiler.com/maps/streets-v2-dark/style.json
   NEXT_PUBLIC_DEFAULT_CITY=tokyo
@@ -204,6 +209,7 @@ git push -u origin main
 
   const envSchema = z.object({
     NEXT_PUBLIC_MAPTILER_KEY: z.string().min(1),
+    NEXT_PUBLIC_OPENWEATHER_KEY: z.string().min(1),
     NEXT_PUBLIC_MAP_STYLE_LIGHT: z.string().url().optional(),
     NEXT_PUBLIC_MAP_STYLE_DARK: z.string().url().optional(),
     NEXT_PUBLIC_DEFAULT_CITY: z.string().default("tokyo"),
@@ -215,6 +221,7 @@ git push -u origin main
 
   export const env = envSchema.parse({
     NEXT_PUBLIC_MAPTILER_KEY: process.env.NEXT_PUBLIC_MAPTILER_KEY,
+    NEXT_PUBLIC_OPENWEATHER_KEY: process.env.NEXT_PUBLIC_OPENWEATHER_KEY,
     NEXT_PUBLIC_MAP_STYLE_LIGHT: process.env.NEXT_PUBLIC_MAP_STYLE_LIGHT,
     NEXT_PUBLIC_MAP_STYLE_DARK: process.env.NEXT_PUBLIC_MAP_STYLE_DARK,
     NEXT_PUBLIC_DEFAULT_CITY: process.env.NEXT_PUBLIC_DEFAULT_CITY,
@@ -227,9 +234,11 @@ git push -u origin main
 - [ ] Vercel プロジェクト作成（GitHub リポジトリと連携）
 - [ ] **Preview 環境** の環境変数を設定
   - `NEXT_PUBLIC_MAPTILER_KEY`: DEV キー
+  - `NEXT_PUBLIC_OPENWEATHER_KEY`: DEV キー
   - その他の環境変数も同様に設定
 - [ ] **Production 環境** の環境変数を設定
   - `NEXT_PUBLIC_MAPTILER_KEY`: PROD キー
+  - `NEXT_PUBLIC_OPENWEATHER_KEY`: PROD キー
   - その他の環境変数も同様に設定
 - [ ] Vercel で `vercel env pull` を実行してローカルに同期（任意）
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -387,6 +387,12 @@ type TimeSlot = {
 - **レート制限**: Free プラン - 100,000 タイル/月
 - **保護**: Allowed HTTP origins 設定必須
 
+### 7.5 OpenWeatherMap Precipitation Tiles
+
+- **用途**: 降水レイヤーの取得
+- **認証**: API キー必要（NEXT_PUBLIC_OPENWEATHER_KEY）
+- **レート制限**: プランに依存（開発用途は無料枠想定）
+
 ---
 
 ## 8. 成功指標（KPI）

--- a/docs/technical-specifications.md
+++ b/docs/technical-specifications.md
@@ -276,6 +276,9 @@ city-observatory/
 # MapTiler（地図タイル）
 NEXT_PUBLIC_MAPTILER_KEY=your_dev_key_here
 
+# OpenWeather（降水レイヤー）
+NEXT_PUBLIC_OPENWEATHER_KEY=your_dev_key_here
+
 # 地図スタイルURL
 NEXT_PUBLIC_MAP_STYLE_LIGHT=https://api.maptiler.com/maps/streets-v2/style.json
 NEXT_PUBLIC_MAP_STYLE_DARK=https://api.maptiler.com/maps/streets-v2-dark/style.json
@@ -295,6 +298,9 @@ NEXT_PUBLIC_SENTRY_DSN=
 ```bash
 # MapTiler API Key（DEV/PROD分ける）
 NEXT_PUBLIC_MAPTILER_KEY=
+
+# OpenWeather API Key
+NEXT_PUBLIC_OPENWEATHER_KEY=
 
 # Map Styles
 NEXT_PUBLIC_MAP_STYLE_LIGHT=
@@ -316,6 +322,9 @@ NEXT_PUBLIC_SENTRY_DSN=
 # MapTiler API Key（PROD）
 NEXT_PUBLIC_MAPTILER_KEY=your_prod_key_here
 
+# OpenWeather API Key
+NEXT_PUBLIC_OPENWEATHER_KEY=your_prod_key_here
+
 # Map Styles
 NEXT_PUBLIC_MAP_STYLE_LIGHT=https://api.maptiler.com/maps/streets-v2/style.json
 NEXT_PUBLIC_MAP_STYLE_DARK=https://api.maptiler.com/maps/streets-v2-dark/style.json
@@ -332,10 +341,12 @@ NEXT_PUBLIC_FEATURE_MAP=true
 **Preview 環境**:
 
 - `NEXT_PUBLIC_MAPTILER_KEY`: DEV キー（localhost + \*.vercel.app 許可）
+- `NEXT_PUBLIC_OPENWEATHER_KEY`: DEV キー
 
 **Production 環境**:
 
 - `NEXT_PUBLIC_MAPTILER_KEY`: PROD キー（本番 URL のみ許可）
+- `NEXT_PUBLIC_OPENWEATHER_KEY`: PROD キー
 
 ### 4.3 環境変数の型定義
 
@@ -345,6 +356,7 @@ import { z } from "zod";
 
 const envSchema = z.object({
   NEXT_PUBLIC_MAPTILER_KEY: z.string().min(1),
+  NEXT_PUBLIC_OPENWEATHER_KEY: z.string().min(1),
   NEXT_PUBLIC_MAP_STYLE_LIGHT: z.string().url().optional(),
   NEXT_PUBLIC_MAP_STYLE_DARK: z.string().url().optional(),
   NEXT_PUBLIC_DEFAULT_CITY: z.string().default("tokyo"),
@@ -356,6 +368,7 @@ const envSchema = z.object({
 
 export const env = envSchema.parse({
   NEXT_PUBLIC_MAPTILER_KEY: process.env.NEXT_PUBLIC_MAPTILER_KEY,
+  NEXT_PUBLIC_OPENWEATHER_KEY: process.env.NEXT_PUBLIC_OPENWEATHER_KEY,
   NEXT_PUBLIC_MAP_STYLE_LIGHT: process.env.NEXT_PUBLIC_MAP_STYLE_LIGHT,
   NEXT_PUBLIC_MAP_STYLE_DARK: process.env.NEXT_PUBLIC_MAP_STYLE_DARK,
   NEXT_PUBLIC_DEFAULT_CITY: process.env.NEXT_PUBLIC_DEFAULT_CITY,

--- a/features/map/ui/map-view-client.tsx
+++ b/features/map/ui/map-view-client.tsx
@@ -33,12 +33,15 @@ type OverlayConfig = {
 
 function getOverlayConfig(type: "none" | "precipitation") {
   if (type === "precipitation") {
+    const tilesUrl = new URL(
+      "https://tile.openweathermap.org/map/precipitation_new/{z}/{x}/{y}.png",
+    );
+    tilesUrl.searchParams.set("appid", env.NEXT_PUBLIC_OPENWEATHER_KEY);
+
     return {
       id: "precipitation-layer",
       sourceId: "precipitation-source",
-      tiles: [
-        "https://tile.openweathermap.org/map/precipitation_new/{z}/{x}/{y}.png",
-      ],
+      tiles: [tilesUrl.toString()],
       opacity: 0.6,
     } satisfies OverlayConfig;
   }

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 const envSchema = z.object({
   NEXT_PUBLIC_MAPTILER_KEY: z.string().min(1),
+  NEXT_PUBLIC_OPENWEATHER_KEY: z.string().min(1),
   NEXT_PUBLIC_MAP_STYLE_LIGHT: z.string().url().optional(),
   NEXT_PUBLIC_MAP_STYLE_DARK: z.string().url().optional(),
   NEXT_PUBLIC_DEFAULT_CITY: z.string().default("tokyo"),
@@ -13,6 +14,7 @@ const envSchema = z.object({
 
 export const env = envSchema.parse({
   NEXT_PUBLIC_MAPTILER_KEY: process.env.NEXT_PUBLIC_MAPTILER_KEY,
+  NEXT_PUBLIC_OPENWEATHER_KEY: process.env.NEXT_PUBLIC_OPENWEATHER_KEY,
   NEXT_PUBLIC_MAP_STYLE_LIGHT: process.env.NEXT_PUBLIC_MAP_STYLE_LIGHT,
   NEXT_PUBLIC_MAP_STYLE_DARK: process.env.NEXT_PUBLIC_MAP_STYLE_DARK,
   NEXT_PUBLIC_DEFAULT_CITY: process.env.NEXT_PUBLIC_DEFAULT_CITY,


### PR DESCRIPTION
# 概要

OpenWeather の降水レイヤー用 API キーを環境変数で扱えるようにし、タイルURLへ反映。

# 背景・目的

- 降水レイヤーの表示に OpenWeather API キーが必要なため

# 変更内容

- `NEXT_PUBLIC_OPENWEATHER_KEY` を環境変数スキーマへ追加
- 降水レイヤーのタイルURLに `appid` を付与
- `.env.example` とドキュメントへキーを追記

# 影響範囲

- 地図の降水レイヤー表示
- 環境変数設定

# テスト

- [ ] 未実施（理由）:
- [ ] 手動:
- [x] 自動: `pnpm typecheck` / `pnpm test`

# スクリーンショット

- [x] 不要
- [ ] 添付

# 関連Issue

- Closes #55
