### PR TITLE
Issue #67: 天気コード対応と背景変化の実装

### DIFF
--- a/app/compare/page.tsx
+++ b/app/compare/page.tsx
@@ -7,8 +7,13 @@ import { WeatherChart } from "@/features/weather/ui/weather-chart";
 import { AQChart } from "@/features/air-quality/ui/aq-chart";
 import { MapView } from "@/features/map/ui/map-view";
 import { useWeatherData } from "@/features/weather/model/use-weather-data";
+import { WeatherIcon } from "@/features/weather/ui/weather-icon";
 import { useAirQualityData } from "@/features/air-quality/model/use-air-quality-data";
 import { getAirQualitySeries } from "@/lib/domain/air-quality-series";
+import {
+  getWeatherBackground,
+  getWeatherClassification,
+} from "@/lib/domain/weather-classification";
 import type { Location } from "@/lib/types/location";
 import { cn } from "@/lib/utils";
 
@@ -135,6 +140,7 @@ export default function ComparePage() {
       apparentTemperature: leftWeather.data.hourly.apparent_temperature[index],
       humidity: leftWeather.data.hourly.relative_humidity_2m[index],
       windSpeed: leftWeather.data.hourly.wind_speed_10m[index],
+      weathercode: leftWeather.data.hourly.weathercode[index],
       precipitationProbability:
         leftWeather.data.hourly.precipitation_probability[index],
     };
@@ -148,14 +154,28 @@ export default function ComparePage() {
       apparentTemperature: rightWeather.data.hourly.apparent_temperature[index],
       humidity: rightWeather.data.hourly.relative_humidity_2m[index],
       windSpeed: rightWeather.data.hourly.wind_speed_10m[index],
+      weathercode: rightWeather.data.hourly.weathercode[index],
       precipitationProbability:
         rightWeather.data.hourly.precipitation_probability[index],
     };
   }, [rightWeather.data]);
 
+  const leftWeatherClassification = leftSnapshot
+    ? getWeatherClassification(leftSnapshot.weathercode)
+    : undefined;
+  const rightWeatherClassification = rightSnapshot
+    ? getWeatherClassification(rightSnapshot.weathercode)
+    : undefined;
+
   // 背景色をデータから生成
   const leftBgColor = temperatureToColor(leftSnapshot?.temperature ?? 20);
   const rightBgColor = temperatureToColor(rightSnapshot?.temperature ?? 20);
+  const leftWeatherBackground = leftSnapshot
+    ? getWeatherBackground(leftSnapshot.weathercode)
+    : undefined;
+  const rightWeatherBackground = rightSnapshot
+    ? getWeatherBackground(rightSnapshot.weathercode)
+    : undefined;
 
   return (
     <div className="relative min-h-screen overflow-hidden">
@@ -165,14 +185,18 @@ export default function ComparePage() {
         <div
           className="absolute left-0 top-0 h-full w-1/2 transition-all duration-1000"
           style={{
-            background: `radial-gradient(ellipse at 20% 50%, hsl(${leftBgColor}, 40%) 0%, hsl(${leftBgColor}, 20%) 40%, transparent 70%)`,
+            background: leftWeatherBackground
+              ? `${leftWeatherBackground}, radial-gradient(ellipse at 20% 50%, hsl(${leftBgColor}, 40%) 0%, hsl(${leftBgColor}, 20%) 40%, transparent 70%)`
+              : `radial-gradient(ellipse at 20% 50%, hsl(${leftBgColor}, 40%) 0%, hsl(${leftBgColor}, 20%) 40%, transparent 70%)`,
           }}
         />
         {/* 右側のグラデーション */}
         <div
           className="absolute right-0 top-0 h-full w-1/2 transition-all duration-1000"
           style={{
-            background: `radial-gradient(ellipse at 80% 50%, hsl(${rightBgColor}, 40%) 0%, hsl(${rightBgColor}, 20%) 40%, transparent 70%)`,
+            background: rightWeatherBackground
+              ? `${rightWeatherBackground}, radial-gradient(ellipse at 80% 50%, hsl(${rightBgColor}, 40%) 0%, hsl(${rightBgColor}, 20%) 40%, transparent 70%)`
+              : `radial-gradient(ellipse at 80% 50%, hsl(${rightBgColor}, 40%) 0%, hsl(${rightBgColor}, 20%) 40%, transparent 70%)`,
           }}
         />
         {/* 中央のブレンド */}
@@ -316,6 +340,16 @@ export default function ComparePage() {
                 precipitationProbability={
                   leftSnapshot?.precipitationProbability ?? 0
                 }
+                icon={
+                  leftWeatherClassification ? (
+                    <WeatherIcon
+                      iconKey={leftWeatherClassification.iconKey}
+                      label={leftWeatherClassification.label}
+                      className="h-5 w-5"
+                    />
+                  ) : undefined
+                }
+                conditionLabel={leftWeatherClassification?.label}
                 isLoading={leftWeather.isLoading}
               />
             </div>
@@ -372,6 +406,16 @@ export default function ComparePage() {
                 precipitationProbability={
                   rightSnapshot?.precipitationProbability ?? 0
                 }
+                icon={
+                  rightWeatherClassification ? (
+                    <WeatherIcon
+                      iconKey={rightWeatherClassification.iconKey}
+                      label={rightWeatherClassification.label}
+                      className="h-5 w-5"
+                    />
+                  ) : undefined
+                }
+                conditionLabel={rightWeatherClassification?.label}
                 isLoading={rightWeather.isLoading}
               />
             </div>

--- a/app/compare/page.tsx
+++ b/app/compare/page.tsx
@@ -10,10 +10,7 @@ import { useWeatherData } from "@/features/weather/model/use-weather-data";
 import { WeatherIcon } from "@/features/weather/ui/weather-icon";
 import { useAirQualityData } from "@/features/air-quality/model/use-air-quality-data";
 import { getAirQualitySeries } from "@/lib/domain/air-quality-series";
-import {
-  getWeatherBackground,
-  getWeatherClassification,
-} from "@/lib/domain/weather-classification";
+import { getWeatherClassification } from "@/lib/domain/weather-classification";
 import type { Location } from "@/lib/types/location";
 import { cn } from "@/lib/utils";
 
@@ -170,13 +167,6 @@ export default function ComparePage() {
   // 背景色をデータから生成
   const leftBgColor = temperatureToColor(leftSnapshot?.temperature ?? 20);
   const rightBgColor = temperatureToColor(rightSnapshot?.temperature ?? 20);
-  const leftWeatherBackground = leftSnapshot
-    ? getWeatherBackground(leftSnapshot.weathercode)
-    : undefined;
-  const rightWeatherBackground = rightSnapshot
-    ? getWeatherBackground(rightSnapshot.weathercode)
-    : undefined;
-
   return (
     <div className="relative min-h-screen overflow-hidden">
       {/* データドリブンな背景グラデーション */}
@@ -185,18 +175,14 @@ export default function ComparePage() {
         <div
           className="absolute left-0 top-0 h-full w-1/2 transition-all duration-1000"
           style={{
-            background: leftWeatherBackground
-              ? `${leftWeatherBackground}, radial-gradient(ellipse at 20% 50%, hsl(${leftBgColor}, 40%) 0%, hsl(${leftBgColor}, 20%) 40%, transparent 70%)`
-              : `radial-gradient(ellipse at 20% 50%, hsl(${leftBgColor}, 40%) 0%, hsl(${leftBgColor}, 20%) 40%, transparent 70%)`,
+            background: `radial-gradient(ellipse at 20% 50%, hsl(${leftBgColor}, 40%) 0%, hsl(${leftBgColor}, 20%) 40%, transparent 70%)`,
           }}
         />
         {/* 右側のグラデーション */}
         <div
           className="absolute right-0 top-0 h-full w-1/2 transition-all duration-1000"
           style={{
-            background: rightWeatherBackground
-              ? `${rightWeatherBackground}, radial-gradient(ellipse at 80% 50%, hsl(${rightBgColor}, 40%) 0%, hsl(${rightBgColor}, 20%) 40%, transparent 70%)`
-              : `radial-gradient(ellipse at 80% 50%, hsl(${rightBgColor}, 40%) 0%, hsl(${rightBgColor}, 20%) 40%, transparent 70%)`,
+            background: `radial-gradient(ellipse at 80% 50%, hsl(${rightBgColor}, 40%) 0%, hsl(${rightBgColor}, 20%) 40%, transparent 70%)`,
           }}
         />
         {/* 中央のブレンド */}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,8 +8,13 @@ import { AQChart } from "@/features/air-quality/ui/aq-chart";
 import { MapView } from "@/features/map/ui/map-view";
 import { MapOverlayToggle } from "@/features/map/ui/map-overlay-toggle";
 import { useWeatherData } from "@/features/weather/model/use-weather-data";
+import { WeatherIcon } from "@/features/weather/ui/weather-icon";
 import { useAirQualityData } from "@/features/air-quality/model/use-air-quality-data";
 import { getAirQualitySeries } from "@/lib/domain/air-quality-series";
+import {
+  getWeatherBackground,
+  getWeatherClassification,
+} from "@/lib/domain/weather-classification";
 import type { Location } from "@/lib/types/location";
 import { cn } from "@/lib/utils";
 
@@ -126,6 +131,7 @@ export default function Home() {
       apparentTemperature: weatherQuery.data.hourly.apparent_temperature[index],
       humidity: weatherQuery.data.hourly.relative_humidity_2m[index],
       windSpeed: weatherQuery.data.hourly.wind_speed_10m[index],
+      weathercode: weatherQuery.data.hourly.weathercode[index],
       precipitationProbability:
         weatherQuery.data.hourly.precipitation_probability[index],
     };
@@ -136,8 +142,15 @@ export default function Home() {
     [airQuery.data],
   );
 
+  const weatherClassification = weatherSnapshot
+    ? getWeatherClassification(weatherSnapshot.weathercode)
+    : undefined;
+
   // 背景色をデータから生成
   const bgColor = temperatureToColor(weatherSnapshot?.temperature ?? 20);
+  const weatherBackground = weatherSnapshot
+    ? getWeatherBackground(weatherSnapshot.weathercode)
+    : undefined;
 
   return (
     <div className="relative min-h-screen overflow-hidden">
@@ -146,7 +159,9 @@ export default function Home() {
         <div
           className="absolute inset-0 transition-all duration-1000"
           style={{
-            background: `radial-gradient(ellipse at 50% 30%, hsl(${bgColor}, 45%) 0%, hsl(${bgColor}, 25%) 30%, transparent 65%)`,
+            background: weatherBackground
+              ? `${weatherBackground}, radial-gradient(ellipse at 50% 30%, hsl(${bgColor}, 45%) 0%, hsl(${bgColor}, 25%) 30%, transparent 65%)`
+              : `radial-gradient(ellipse at 50% 30%, hsl(${bgColor}, 45%) 0%, hsl(${bgColor}, 25%) 30%, transparent 65%)`,
           }}
         />
         <div className="absolute inset-0 -z-10 bg-background" />
@@ -222,6 +237,16 @@ export default function Home() {
                 precipitationProbability={
                   weatherSnapshot?.precipitationProbability ?? 0
                 }
+                icon={
+                  weatherClassification ? (
+                    <WeatherIcon
+                      iconKey={weatherClassification.iconKey}
+                      label={weatherClassification.label}
+                      className="h-5 w-5"
+                    />
+                  ) : undefined
+                }
+                conditionLabel={weatherClassification?.label}
                 isLoading={weatherQuery.isLoading}
               />
             </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,10 +11,7 @@ import { useWeatherData } from "@/features/weather/model/use-weather-data";
 import { WeatherIcon } from "@/features/weather/ui/weather-icon";
 import { useAirQualityData } from "@/features/air-quality/model/use-air-quality-data";
 import { getAirQualitySeries } from "@/lib/domain/air-quality-series";
-import {
-  getWeatherBackground,
-  getWeatherClassification,
-} from "@/lib/domain/weather-classification";
+import { getWeatherClassification } from "@/lib/domain/weather-classification";
 import type { Location } from "@/lib/types/location";
 import { cn } from "@/lib/utils";
 
@@ -148,10 +145,6 @@ export default function Home() {
 
   // 背景色をデータから生成
   const bgColor = temperatureToColor(weatherSnapshot?.temperature ?? 20);
-  const weatherBackground = weatherSnapshot
-    ? getWeatherBackground(weatherSnapshot.weathercode)
-    : undefined;
-
   return (
     <div className="relative min-h-screen overflow-hidden">
       {/* データドリブンな背景グラデーション */}
@@ -159,9 +152,7 @@ export default function Home() {
         <div
           className="absolute inset-0 transition-all duration-1000"
           style={{
-            background: weatherBackground
-              ? `${weatherBackground}, radial-gradient(ellipse at 50% 30%, hsl(${bgColor}, 45%) 0%, hsl(${bgColor}, 25%) 30%, transparent 65%)`
-              : `radial-gradient(ellipse at 50% 30%, hsl(${bgColor}, 45%) 0%, hsl(${bgColor}, 25%) 30%, transparent 65%)`,
+            background: `radial-gradient(ellipse at 50% 30%, hsl(${bgColor}, 45%) 0%, hsl(${bgColor}, 25%) 30%, transparent 65%)`,
           }}
         />
         <div className="absolute inset-0 -z-10 bg-background" />

--- a/features/weather/ui/weather-card.tsx
+++ b/features/weather/ui/weather-card.tsx
@@ -7,6 +7,7 @@ type WeatherCardProps = {
   windSpeed: number;
   precipitationProbability: number;
   icon?: ReactNode;
+  conditionLabel?: string;
   isLoading?: boolean;
 };
 
@@ -17,6 +18,7 @@ export function WeatherCard({
   windSpeed,
   precipitationProbability,
   icon,
+  conditionLabel,
   isLoading = false,
 }: WeatherCardProps) {
   if (isLoading) {
@@ -37,7 +39,14 @@ export function WeatherCard({
   return (
     <div>
       <div className="flex items-center justify-between text-sm text-muted-foreground">
-        <span>現在の天気</span>
+        <div className="flex items-center gap-2">
+          <span>現在の天気</span>
+          {conditionLabel ? (
+            <span className="rounded-full bg-foreground/10 px-2 py-0.5 text-xs text-foreground">
+              {conditionLabel}
+            </span>
+          ) : null}
+        </div>
         {icon}
       </div>
       <div className="mt-3 text-5xl font-bold tracking-tight">

--- a/features/weather/ui/weather-icon.tsx
+++ b/features/weather/ui/weather-icon.tsx
@@ -1,0 +1,48 @@
+import type { ComponentProps } from "react";
+import {
+  Cloud,
+  CloudAlert,
+  CloudDrizzle,
+  CloudFog,
+  CloudLightning,
+  CloudRain,
+  CloudSnow,
+  CloudSun,
+  Sun,
+} from "lucide-react";
+import type { WeatherIconKey } from "@/lib/domain/weather-classification";
+import { cn } from "@/lib/utils";
+
+type WeatherIconProps = {
+  iconKey: WeatherIconKey;
+  label?: string;
+} & Omit<ComponentProps<"svg">, "children">;
+
+const weatherIconMap: Record<WeatherIconKey, typeof Sun> = {
+  sun: Sun,
+  "cloud-sun": CloudSun,
+  cloud: Cloud,
+  "cloud-fog": CloudFog,
+  "cloud-drizzle": CloudDrizzle,
+  "cloud-rain": CloudRain,
+  "cloud-snow": CloudSnow,
+  "cloud-lightning": CloudLightning,
+  "cloud-alert": CloudAlert,
+};
+
+export function WeatherIcon({
+  iconKey,
+  label,
+  className,
+  ...props
+}: WeatherIconProps) {
+  const Icon = weatherIconMap[iconKey] ?? Cloud;
+  return (
+    <Icon
+      className={cn("h-5 w-5 text-foreground/80", className)}
+      aria-label={label}
+      role={label ? "img" : "presentation"}
+      {...props}
+    />
+  );
+}

--- a/lib/domain/weather-classification.ts
+++ b/lib/domain/weather-classification.ts
@@ -12,10 +12,21 @@ export type WeatherCondition =
   | "thunderstorm"
   | "unknown";
 
+export type WeatherIconKey =
+  | "sun"
+  | "cloud-sun"
+  | "cloud"
+  | "cloud-fog"
+  | "cloud-drizzle"
+  | "cloud-rain"
+  | "cloud-snow"
+  | "cloud-lightning"
+  | "cloud-alert";
+
 type WeatherClassification = {
   condition: WeatherCondition;
   label: string;
-  iconKey: string;
+  iconKey: WeatherIconKey;
   background: string;
 };
 
@@ -34,7 +45,7 @@ const weatherLabels: Record<WeatherCondition, string> = {
   unknown: "不明",
 };
 
-const weatherIcons: Record<WeatherCondition, string> = {
+const weatherIcons: Record<WeatherCondition, WeatherIconKey> = {
   clear: "sun",
   "mostly-clear": "sun",
   "partly-cloudy": "cloud-sun",


### PR DESCRIPTION
# 概要

天気コードに応じた背景グラデーションと天気アイコン表示を追加しました。

# 背景・目的

- Issue #67 の実装
- 「パッと見すごい」演出の強化

# 変更内容

- WeatherCodeに応じた背景グラデーションを適用
- 天気アイコンとラベル表示をWeatherCardに追加
- 天気アイコンのUIコンポーネントを追加

# 影響範囲

- `app/page.tsx`
- `app/compare/page.tsx`
- `features/weather/ui/weather-card.tsx`
- `features/weather/ui/weather-icon.tsx`
- `lib/domain/weather-classification.ts`

# テスト

- [ ] 未実施（理由）:
- [ ] 手動:
- [x] 自動: `pnpm typecheck`, `pnpm test`

# スクリーンショット

- [ ] 不要
- [ ] 添付

# 関連Issue

- Closes #67
