### PR TITLE
Issue #68: UV指数カードの実装

### DIFF
--- a/app/compare/page.tsx
+++ b/app/compare/page.tsx
@@ -8,9 +8,11 @@ import { AQChart } from "@/features/air-quality/ui/aq-chart";
 import { MapView } from "@/features/map/ui/map-view";
 import { useWeatherData } from "@/features/weather/model/use-weather-data";
 import { WeatherIcon } from "@/features/weather/ui/weather-icon";
+import { UVCard } from "@/features/weather/ui/uv-card";
 import { useAirQualityData } from "@/features/air-quality/model/use-air-quality-data";
 import { getAirQualitySeries } from "@/lib/domain/air-quality-series";
 import { getWeatherClassification } from "@/lib/domain/weather-classification";
+import { getUVClassification } from "@/lib/domain/uv-classification";
 import type { Location } from "@/lib/types/location";
 import { cn } from "@/lib/utils";
 
@@ -138,6 +140,7 @@ export default function ComparePage() {
       humidity: leftWeather.data.hourly.relative_humidity_2m[index],
       windSpeed: leftWeather.data.hourly.wind_speed_10m[index],
       weathercode: leftWeather.data.hourly.weathercode[index],
+      uvIndex: leftWeather.data.hourly.uv_index[index],
       precipitationProbability:
         leftWeather.data.hourly.precipitation_probability[index],
     };
@@ -152,6 +155,7 @@ export default function ComparePage() {
       humidity: rightWeather.data.hourly.relative_humidity_2m[index],
       windSpeed: rightWeather.data.hourly.wind_speed_10m[index],
       weathercode: rightWeather.data.hourly.weathercode[index],
+      uvIndex: rightWeather.data.hourly.uv_index[index],
       precipitationProbability:
         rightWeather.data.hourly.precipitation_probability[index],
     };
@@ -163,6 +167,14 @@ export default function ComparePage() {
   const rightWeatherClassification = rightSnapshot
     ? getWeatherClassification(rightSnapshot.weathercode)
     : undefined;
+  const leftUvClassification = leftSnapshot
+    ? getUVClassification(leftSnapshot.uvIndex)
+    : undefined;
+  const rightUvClassification = rightSnapshot
+    ? getUVClassification(rightSnapshot.uvIndex)
+    : undefined;
+  const leftUvIndexMax = leftWeather.data?.daily?.uv_index_max?.[0];
+  const rightUvIndexMax = rightWeather.data?.daily?.uv_index_max?.[0];
 
   // 背景色をデータから生成
   const leftBgColor = temperatureToColor(leftSnapshot?.temperature ?? 20);
@@ -340,6 +352,17 @@ export default function ComparePage() {
               />
             </div>
 
+            {/* UV指数 */}
+            <div className="group rounded-3xl border border-foreground/10 bg-background/50 p-6 backdrop-blur-2xl transition-all duration-300 hover:border-foreground/20 hover:bg-background/60 hover:shadow-2xl hover:-translate-y-1">
+              <UVCard
+                uvIndex={leftSnapshot?.uvIndex ?? 0}
+                uvIndexMax={leftUvIndexMax}
+                label={leftUvClassification?.label ?? "不明"}
+                color={leftUvClassification?.color ?? "hsl(0, 0%, 60%)"}
+                isLoading={leftWeather.isLoading}
+              />
+            </div>
+
             {/* 気温の推移 */}
             {leftWeather.data?.hourly ? (
               <div className="group rounded-3xl border border-foreground/10 bg-background/50 p-6 backdrop-blur-2xl transition-all duration-300 hover:border-foreground/20 hover:bg-background/60 hover:shadow-2xl hover:-translate-y-1">
@@ -402,6 +425,17 @@ export default function ComparePage() {
                   ) : undefined
                 }
                 conditionLabel={rightWeatherClassification?.label}
+                isLoading={rightWeather.isLoading}
+              />
+            </div>
+
+            {/* UV指数 */}
+            <div className="group rounded-3xl border border-foreground/10 bg-background/50 p-6 backdrop-blur-2xl transition-all duration-300 hover:border-foreground/20 hover:bg-background/60 hover:shadow-2xl hover:-translate-y-1">
+              <UVCard
+                uvIndex={rightSnapshot?.uvIndex ?? 0}
+                uvIndexMax={rightUvIndexMax}
+                label={rightUvClassification?.label ?? "不明"}
+                color={rightUvClassification?.color ?? "hsl(0, 0%, 60%)"}
                 isLoading={rightWeather.isLoading}
               />
             </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,9 +9,11 @@ import { MapView } from "@/features/map/ui/map-view";
 import { MapOverlayToggle } from "@/features/map/ui/map-overlay-toggle";
 import { useWeatherData } from "@/features/weather/model/use-weather-data";
 import { WeatherIcon } from "@/features/weather/ui/weather-icon";
+import { UVCard } from "@/features/weather/ui/uv-card";
 import { useAirQualityData } from "@/features/air-quality/model/use-air-quality-data";
 import { getAirQualitySeries } from "@/lib/domain/air-quality-series";
 import { getWeatherClassification } from "@/lib/domain/weather-classification";
+import { getUVClassification } from "@/lib/domain/uv-classification";
 import type { Location } from "@/lib/types/location";
 import { cn } from "@/lib/utils";
 
@@ -129,6 +131,7 @@ export default function Home() {
       humidity: weatherQuery.data.hourly.relative_humidity_2m[index],
       windSpeed: weatherQuery.data.hourly.wind_speed_10m[index],
       weathercode: weatherQuery.data.hourly.weathercode[index],
+      uvIndex: weatherQuery.data.hourly.uv_index[index],
       precipitationProbability:
         weatherQuery.data.hourly.precipitation_probability[index],
     };
@@ -142,6 +145,10 @@ export default function Home() {
   const weatherClassification = weatherSnapshot
     ? getWeatherClassification(weatherSnapshot.weathercode)
     : undefined;
+  const uvClassification = weatherSnapshot
+    ? getUVClassification(weatherSnapshot.uvIndex)
+    : undefined;
+  const uvIndexMax = weatherQuery.data?.daily?.uv_index_max?.[0];
 
   // 背景色をデータから生成
   const bgColor = temperatureToColor(weatherSnapshot?.temperature ?? 20);
@@ -238,6 +245,17 @@ export default function Home() {
                   ) : undefined
                 }
                 conditionLabel={weatherClassification?.label}
+                isLoading={weatherQuery.isLoading}
+              />
+            </div>
+
+            {/* UV指数 */}
+            <div className="group rounded-3xl border border-foreground/10 bg-background/50 p-6 backdrop-blur-2xl transition-all duration-300 hover:border-foreground/20 hover:bg-background/60 hover:shadow-2xl hover:-translate-y-1">
+              <UVCard
+                uvIndex={weatherSnapshot?.uvIndex ?? 0}
+                uvIndexMax={uvIndexMax}
+                label={uvClassification?.label ?? "不明"}
+                color={uvClassification?.color ?? "hsl(0, 0%, 60%)"}
                 isLoading={weatherQuery.isLoading}
               />
             </div>

--- a/features/weather/ui/uv-card.tsx
+++ b/features/weather/ui/uv-card.tsx
@@ -1,0 +1,61 @@
+type UVCardProps = {
+  uvIndex: number;
+  uvIndexMax?: number;
+  label: string;
+  color: string;
+  isLoading?: boolean;
+};
+
+export function UVCard({
+  uvIndex,
+  uvIndexMax,
+  label,
+  color,
+  isLoading = false,
+}: UVCardProps) {
+  if (isLoading) {
+    return (
+      <div>
+        <div className="h-6 w-24 animate-pulse rounded-md bg-muted/50" />
+        <div className="mt-4 h-12 w-24 animate-pulse rounded-md bg-muted/50" />
+        <div className="mt-6 h-5 w-32 animate-pulse rounded-md bg-muted/50" />
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className="flex items-center justify-between text-sm text-muted-foreground">
+        <span>UV指数</span>
+        <span className="rounded-full bg-foreground/10 px-2 py-0.5 text-xs text-foreground">
+          {label}
+        </span>
+      </div>
+      <div className="mt-3 flex items-end gap-2">
+        <span className="text-5xl font-bold tracking-tight">
+          {uvIndex.toFixed(1)}
+        </span>
+        <span className="text-sm text-muted-foreground">/ 11+</span>
+      </div>
+      <div className="mt-6">
+        <div className="h-2 w-full rounded-full bg-muted/40">
+          <div
+            className="h-2 rounded-full transition-all duration-700"
+            style={{
+              width: `${Math.min((uvIndex / 11) * 100, 100)}%`,
+              backgroundColor: color,
+            }}
+          />
+        </div>
+        <div className="mt-2 flex items-center justify-between text-xs text-muted-foreground">
+          <span>低い</span>
+          {uvIndexMax !== undefined ? (
+            <span>最大 {uvIndexMax.toFixed(1)}</span>
+          ) : (
+            <span>極端</span>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
# 概要

UV指数カードを追加し、現在値と最大値を可視化できるようにしました。

# 背景・目的

- Issue #68 の実装
- 天候可視化の情報密度を高めるため

# 変更内容

- UV指数カードのUIコンポーネントを追加
- トップ/比較ページにUV指数カードを配置
- UV指数の分類ラベル・色分けを反映

# 影響範囲

- `features/weather/ui/uv-card.tsx`
- `app/page.tsx`
- `app/compare/page.tsx`

# テスト

- [ ] 未実施（理由）:
- [ ] 手動:
- [x] 自動: `pnpm typecheck`, `pnpm test`

# スクリーンショット

- [ ] 不要
- [ ] 添付

# 関連Issue

- Closes #68
