### PR TITLE
Issue #69: 風向きカードの実装

### DIFF
--- a/app/compare/page.tsx
+++ b/app/compare/page.tsx
@@ -9,10 +9,15 @@ import { MapView } from "@/features/map/ui/map-view";
 import { useWeatherData } from "@/features/weather/model/use-weather-data";
 import { WeatherIcon } from "@/features/weather/ui/weather-icon";
 import { UVCard } from "@/features/weather/ui/uv-card";
+import { WindCard } from "@/features/weather/ui/wind-card";
 import { useAirQualityData } from "@/features/air-quality/model/use-air-quality-data";
 import { getAirQualitySeries } from "@/lib/domain/air-quality-series";
 import { getWeatherClassification } from "@/lib/domain/weather-classification";
 import { getUVClassification } from "@/lib/domain/uv-classification";
+import {
+  getWindDirectionLabel,
+  getWindDirectionRotation,
+} from "@/lib/domain/wind-direction";
 import type { Location } from "@/lib/types/location";
 import { cn } from "@/lib/utils";
 
@@ -139,6 +144,7 @@ export default function ComparePage() {
       apparentTemperature: leftWeather.data.hourly.apparent_temperature[index],
       humidity: leftWeather.data.hourly.relative_humidity_2m[index],
       windSpeed: leftWeather.data.hourly.wind_speed_10m[index],
+      windDirection: leftWeather.data.hourly.wind_direction_10m[index],
       weathercode: leftWeather.data.hourly.weathercode[index],
       uvIndex: leftWeather.data.hourly.uv_index[index],
       precipitationProbability:
@@ -154,6 +160,7 @@ export default function ComparePage() {
       apparentTemperature: rightWeather.data.hourly.apparent_temperature[index],
       humidity: rightWeather.data.hourly.relative_humidity_2m[index],
       windSpeed: rightWeather.data.hourly.wind_speed_10m[index],
+      windDirection: rightWeather.data.hourly.wind_direction_10m[index],
       weathercode: rightWeather.data.hourly.weathercode[index],
       uvIndex: rightWeather.data.hourly.uv_index[index],
       precipitationProbability:
@@ -175,6 +182,18 @@ export default function ComparePage() {
     : undefined;
   const leftUvIndexMax = leftWeather.data?.daily?.uv_index_max?.[0];
   const rightUvIndexMax = rightWeather.data?.daily?.uv_index_max?.[0];
+  const leftWindDirectionLabel = leftSnapshot
+    ? getWindDirectionLabel(leftSnapshot.windDirection)
+    : "不明";
+  const rightWindDirectionLabel = rightSnapshot
+    ? getWindDirectionLabel(rightSnapshot.windDirection)
+    : "不明";
+  const leftWindDirectionRotation = leftSnapshot
+    ? getWindDirectionRotation(leftSnapshot.windDirection)
+    : 0;
+  const rightWindDirectionRotation = rightSnapshot
+    ? getWindDirectionRotation(rightSnapshot.windDirection)
+    : 0;
 
   // 背景色をデータから生成
   const leftBgColor = temperatureToColor(leftSnapshot?.temperature ?? 20);
@@ -363,6 +382,16 @@ export default function ComparePage() {
               />
             </div>
 
+            {/* 風向き・風速 */}
+            <div className="group rounded-3xl border border-foreground/10 bg-background/50 p-6 backdrop-blur-2xl transition-all duration-300 hover:border-foreground/20 hover:bg-background/60 hover:shadow-2xl hover:-translate-y-1">
+              <WindCard
+                windSpeed={leftSnapshot?.windSpeed ?? 0}
+                windDirection={leftWindDirectionRotation}
+                directionLabel={leftWindDirectionLabel}
+                isLoading={leftWeather.isLoading}
+              />
+            </div>
+
             {/* 気温の推移 */}
             {leftWeather.data?.hourly ? (
               <div className="group rounded-3xl border border-foreground/10 bg-background/50 p-6 backdrop-blur-2xl transition-all duration-300 hover:border-foreground/20 hover:bg-background/60 hover:shadow-2xl hover:-translate-y-1">
@@ -436,6 +465,16 @@ export default function ComparePage() {
                 uvIndexMax={rightUvIndexMax}
                 label={rightUvClassification?.label ?? "不明"}
                 color={rightUvClassification?.color ?? "hsl(0, 0%, 60%)"}
+                isLoading={rightWeather.isLoading}
+              />
+            </div>
+
+            {/* 風向き・風速 */}
+            <div className="group rounded-3xl border border-foreground/10 bg-background/50 p-6 backdrop-blur-2xl transition-all duration-300 hover:border-foreground/20 hover:bg-background/60 hover:shadow-2xl hover:-translate-y-1">
+              <WindCard
+                windSpeed={rightSnapshot?.windSpeed ?? 0}
+                windDirection={rightWindDirectionRotation}
+                directionLabel={rightWindDirectionLabel}
                 isLoading={rightWeather.isLoading}
               />
             </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -10,10 +10,15 @@ import { MapOverlayToggle } from "@/features/map/ui/map-overlay-toggle";
 import { useWeatherData } from "@/features/weather/model/use-weather-data";
 import { WeatherIcon } from "@/features/weather/ui/weather-icon";
 import { UVCard } from "@/features/weather/ui/uv-card";
+import { WindCard } from "@/features/weather/ui/wind-card";
 import { useAirQualityData } from "@/features/air-quality/model/use-air-quality-data";
 import { getAirQualitySeries } from "@/lib/domain/air-quality-series";
 import { getWeatherClassification } from "@/lib/domain/weather-classification";
 import { getUVClassification } from "@/lib/domain/uv-classification";
+import {
+  getWindDirectionLabel,
+  getWindDirectionRotation,
+} from "@/lib/domain/wind-direction";
 import type { Location } from "@/lib/types/location";
 import { cn } from "@/lib/utils";
 
@@ -130,6 +135,7 @@ export default function Home() {
       apparentTemperature: weatherQuery.data.hourly.apparent_temperature[index],
       humidity: weatherQuery.data.hourly.relative_humidity_2m[index],
       windSpeed: weatherQuery.data.hourly.wind_speed_10m[index],
+      windDirection: weatherQuery.data.hourly.wind_direction_10m[index],
       weathercode: weatherQuery.data.hourly.weathercode[index],
       uvIndex: weatherQuery.data.hourly.uv_index[index],
       precipitationProbability:
@@ -149,6 +155,12 @@ export default function Home() {
     ? getUVClassification(weatherSnapshot.uvIndex)
     : undefined;
   const uvIndexMax = weatherQuery.data?.daily?.uv_index_max?.[0];
+  const windDirectionLabel = weatherSnapshot
+    ? getWindDirectionLabel(weatherSnapshot.windDirection)
+    : "不明";
+  const windDirectionRotation = weatherSnapshot
+    ? getWindDirectionRotation(weatherSnapshot.windDirection)
+    : 0;
 
   // 背景色をデータから生成
   const bgColor = temperatureToColor(weatherSnapshot?.temperature ?? 20);
@@ -256,6 +268,16 @@ export default function Home() {
                 uvIndexMax={uvIndexMax}
                 label={uvClassification?.label ?? "不明"}
                 color={uvClassification?.color ?? "hsl(0, 0%, 60%)"}
+                isLoading={weatherQuery.isLoading}
+              />
+            </div>
+
+            {/* 風向き・風速 */}
+            <div className="group rounded-3xl border border-foreground/10 bg-background/50 p-6 backdrop-blur-2xl transition-all duration-300 hover:border-foreground/20 hover:bg-background/60 hover:shadow-2xl hover:-translate-y-1">
+              <WindCard
+                windSpeed={weatherSnapshot?.windSpeed ?? 0}
+                windDirection={windDirectionRotation}
+                directionLabel={windDirectionLabel}
                 isLoading={weatherQuery.isLoading}
               />
             </div>

--- a/features/weather/ui/wind-card.tsx
+++ b/features/weather/ui/wind-card.tsx
@@ -1,0 +1,56 @@
+type WindCardProps = {
+  windSpeed: number;
+  windDirection: number;
+  directionLabel: string;
+  isLoading?: boolean;
+};
+
+export function WindCard({
+  windSpeed,
+  windDirection,
+  directionLabel,
+  isLoading = false,
+}: WindCardProps) {
+  if (isLoading) {
+    return (
+      <div>
+        <div className="h-6 w-24 animate-pulse rounded-md bg-muted/50" />
+        <div className="mt-4 h-12 w-20 animate-pulse rounded-md bg-muted/50" />
+        <div className="mt-6 h-5 w-32 animate-pulse rounded-md bg-muted/50" />
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className="flex items-center justify-between text-sm text-muted-foreground">
+        <span>風向き・風速</span>
+        <span className="rounded-full bg-foreground/10 px-2 py-0.5 text-xs text-foreground">
+          {directionLabel}
+        </span>
+      </div>
+      <div className="mt-4 flex items-center gap-4">
+        <div className="relative flex h-16 w-16 items-center justify-center rounded-full border border-foreground/15 bg-background/60">
+          <div className="absolute h-10 w-10 rounded-full border border-dashed border-foreground/20" />
+          <div
+            className="absolute h-12 w-12 transition-transform duration-700"
+            style={{ transform: `rotate(${windDirection}deg)` }}
+          >
+            <div className="absolute left-1/2 top-1 h-7 w-[2px] -translate-x-1/2 rounded-full bg-foreground/80" />
+            <div className="absolute left-1/2 top-0 h-2 w-2 -translate-x-1/2 rotate-45 border-2 border-foreground/80 border-b-0 border-l-0" />
+          </div>
+        </div>
+        <div>
+          <div className="text-4xl font-bold tracking-tight">
+            {windSpeed.toFixed(1)}
+          </div>
+          <div className="text-sm text-muted-foreground">m/s</div>
+        </div>
+      </div>
+      <div className="mt-5 flex items-center justify-between text-xs text-muted-foreground">
+        <span>北</span>
+        <span>南</span>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
# 概要

風向き・風速カードを追加し、矢印と方角ラベルで視覚化しました。

# 背景・目的

- Issue #69 の実装
- 風の流れを直感的に伝えるため

# 変更内容

- 風向きカードUIコンポーネントを追加
- トップ/比較ページに風向きカードを配置
- 風向きラベルと回転角のロジックを反映

# 影響範囲

- `features/weather/ui/wind-card.tsx`
- `app/page.tsx`
- `app/compare/page.tsx`

# テスト

- [ ] 未実施（理由）:
- [ ] 手動:
- [x] 自動: `pnpm typecheck`, `pnpm test`

# スクリーンショット

- [ ] 不要
- [ ] 添付

# 関連Issue

- Closes #69
