### PR TITLE
Issue #70: 日の出/日の入り可視化の実装

### DIFF
--- a/app/compare/page.tsx
+++ b/app/compare/page.tsx
@@ -10,6 +10,7 @@ import { useWeatherData } from "@/features/weather/model/use-weather-data";
 import { WeatherIcon } from "@/features/weather/ui/weather-icon";
 import { UVCard } from "@/features/weather/ui/uv-card";
 import { WindCard } from "@/features/weather/ui/wind-card";
+import { SunPathCard } from "@/features/weather/ui/sun-path-card";
 import { useAirQualityData } from "@/features/air-quality/model/use-air-quality-data";
 import { getAirQualitySeries } from "@/lib/domain/air-quality-series";
 import { getWeatherClassification } from "@/lib/domain/weather-classification";
@@ -18,6 +19,12 @@ import {
   getWindDirectionLabel,
   getWindDirectionRotation,
 } from "@/lib/domain/wind-direction";
+import {
+  getSunPhase,
+  getSunPhaseBackground,
+  getSunPhaseLabel,
+  getSunProgress,
+} from "@/lib/domain/sun-path";
 import type { Location } from "@/lib/types/location";
 import { cn } from "@/lib/utils";
 
@@ -194,6 +201,42 @@ export default function ComparePage() {
   const rightWindDirectionRotation = rightSnapshot
     ? getWindDirectionRotation(rightSnapshot.windDirection)
     : 0;
+  const leftSunriseAt = leftWeather.data?.daily?.sunrise?.[0];
+  const leftSunsetAt = leftWeather.data?.daily?.sunset?.[0];
+  const rightSunriseAt = rightWeather.data?.daily?.sunrise?.[0];
+  const rightSunsetAt = rightWeather.data?.daily?.sunset?.[0];
+  const leftSunPhase =
+    leftSunriseAt && leftSunsetAt
+      ? getSunPhase(new Date(), new Date(leftSunriseAt), new Date(leftSunsetAt))
+      : "night";
+  const rightSunPhase =
+    rightSunriseAt && rightSunsetAt
+      ? getSunPhase(
+          new Date(),
+          new Date(rightSunriseAt),
+          new Date(rightSunsetAt),
+        )
+      : "night";
+  const leftSunProgress =
+    leftSunriseAt && leftSunsetAt
+      ? getSunProgress(
+          new Date(),
+          new Date(leftSunriseAt),
+          new Date(leftSunsetAt),
+        )
+      : 0;
+  const rightSunProgress =
+    rightSunriseAt && rightSunsetAt
+      ? getSunProgress(
+          new Date(),
+          new Date(rightSunriseAt),
+          new Date(rightSunsetAt),
+        )
+      : 0;
+  const leftSunPhaseLabel = getSunPhaseLabel(leftSunPhase);
+  const rightSunPhaseLabel = getSunPhaseLabel(rightSunPhase);
+  const leftSunPhaseBackground = getSunPhaseBackground(leftSunPhase);
+  const rightSunPhaseBackground = getSunPhaseBackground(rightSunPhase);
 
   // 背景色をデータから生成
   const leftBgColor = temperatureToColor(leftSnapshot?.temperature ?? 20);
@@ -392,6 +435,27 @@ export default function ComparePage() {
               />
             </div>
 
+            {/* 日の出/日の入り */}
+            {leftSunriseAt && leftSunsetAt ? (
+              <div className="group rounded-3xl border border-foreground/10 bg-background/50 p-6 backdrop-blur-2xl transition-all duration-300 hover:border-foreground/20 hover:bg-background/60 hover:shadow-2xl hover:-translate-y-1">
+                <SunPathCard
+                  sunrise={new Date(leftSunriseAt).toLocaleTimeString("ja-JP", {
+                    hour: "2-digit",
+                    minute: "2-digit",
+                  })}
+                  sunset={new Date(leftSunsetAt).toLocaleTimeString("ja-JP", {
+                    hour: "2-digit",
+                    minute: "2-digit",
+                  })}
+                  nowLabel={formatLocalTime(leftCity.timezone)}
+                  phaseLabel={leftSunPhaseLabel}
+                  progress={leftSunProgress}
+                  background={leftSunPhaseBackground}
+                  isLoading={leftWeather.isLoading}
+                />
+              </div>
+            ) : null}
+
             {/* 気温の推移 */}
             {leftWeather.data?.hourly ? (
               <div className="group rounded-3xl border border-foreground/10 bg-background/50 p-6 backdrop-blur-2xl transition-all duration-300 hover:border-foreground/20 hover:bg-background/60 hover:shadow-2xl hover:-translate-y-1">
@@ -478,6 +542,30 @@ export default function ComparePage() {
                 isLoading={rightWeather.isLoading}
               />
             </div>
+
+            {/* 日の出/日の入り */}
+            {rightSunriseAt && rightSunsetAt ? (
+              <div className="group rounded-3xl border border-foreground/10 bg-background/50 p-6 backdrop-blur-2xl transition-all duration-300 hover:border-foreground/20 hover:bg-background/60 hover:shadow-2xl hover:-translate-y-1">
+                <SunPathCard
+                  sunrise={new Date(rightSunriseAt).toLocaleTimeString(
+                    "ja-JP",
+                    {
+                      hour: "2-digit",
+                      minute: "2-digit",
+                    },
+                  )}
+                  sunset={new Date(rightSunsetAt).toLocaleTimeString("ja-JP", {
+                    hour: "2-digit",
+                    minute: "2-digit",
+                  })}
+                  nowLabel={formatLocalTime(rightCity.timezone)}
+                  phaseLabel={rightSunPhaseLabel}
+                  progress={rightSunProgress}
+                  background={rightSunPhaseBackground}
+                  isLoading={rightWeather.isLoading}
+                />
+              </div>
+            ) : null}
 
             {/* 気温の推移 */}
             {rightWeather.data?.hourly ? (

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,6 +11,7 @@ import { useWeatherData } from "@/features/weather/model/use-weather-data";
 import { WeatherIcon } from "@/features/weather/ui/weather-icon";
 import { UVCard } from "@/features/weather/ui/uv-card";
 import { WindCard } from "@/features/weather/ui/wind-card";
+import { SunPathCard } from "@/features/weather/ui/sun-path-card";
 import { useAirQualityData } from "@/features/air-quality/model/use-air-quality-data";
 import { getAirQualitySeries } from "@/lib/domain/air-quality-series";
 import { getWeatherClassification } from "@/lib/domain/weather-classification";
@@ -19,6 +20,12 @@ import {
   getWindDirectionLabel,
   getWindDirectionRotation,
 } from "@/lib/domain/wind-direction";
+import {
+  getSunPhase,
+  getSunPhaseBackground,
+  getSunPhaseLabel,
+  getSunProgress,
+} from "@/lib/domain/sun-path";
 import type { Location } from "@/lib/types/location";
 import { cn } from "@/lib/utils";
 
@@ -161,6 +168,18 @@ export default function Home() {
   const windDirectionRotation = weatherSnapshot
     ? getWindDirectionRotation(weatherSnapshot.windDirection)
     : 0;
+  const sunriseAt = weatherQuery.data?.daily?.sunrise?.[0];
+  const sunsetAt = weatherQuery.data?.daily?.sunset?.[0];
+  const sunPhase =
+    sunriseAt && sunsetAt
+      ? getSunPhase(new Date(), new Date(sunriseAt), new Date(sunsetAt))
+      : "night";
+  const sunProgress =
+    sunriseAt && sunsetAt
+      ? getSunProgress(new Date(), new Date(sunriseAt), new Date(sunsetAt))
+      : 0;
+  const sunPhaseLabel = getSunPhaseLabel(sunPhase);
+  const sunPhaseBackground = getSunPhaseBackground(sunPhase);
 
   // 背景色をデータから生成
   const bgColor = temperatureToColor(weatherSnapshot?.temperature ?? 20);
@@ -281,6 +300,27 @@ export default function Home() {
                 isLoading={weatherQuery.isLoading}
               />
             </div>
+
+            {/* 日の出/日の入り */}
+            {sunriseAt && sunsetAt ? (
+              <div className="group rounded-3xl border border-foreground/10 bg-background/50 p-6 backdrop-blur-2xl transition-all duration-300 hover:border-foreground/20 hover:bg-background/60 hover:shadow-2xl hover:-translate-y-1">
+                <SunPathCard
+                  sunrise={new Date(sunriseAt).toLocaleTimeString("ja-JP", {
+                    hour: "2-digit",
+                    minute: "2-digit",
+                  })}
+                  sunset={new Date(sunsetAt).toLocaleTimeString("ja-JP", {
+                    hour: "2-digit",
+                    minute: "2-digit",
+                  })}
+                  nowLabel={formatLocalTime(activeCity.timezone)}
+                  phaseLabel={sunPhaseLabel}
+                  progress={sunProgress}
+                  background={sunPhaseBackground}
+                  isLoading={weatherQuery.isLoading}
+                />
+              </div>
+            ) : null}
 
             {/* 気温の推移 */}
             {weatherQuery.data?.hourly ? (

--- a/features/weather/ui/sun-path-card.tsx
+++ b/features/weather/ui/sun-path-card.tsx
@@ -1,0 +1,81 @@
+type SunPathCardProps = {
+  sunrise: string;
+  sunset: string;
+  nowLabel: string;
+  phaseLabel: string;
+  progress: number;
+  background: string;
+  isLoading?: boolean;
+};
+
+export function SunPathCard({
+  sunrise,
+  sunset,
+  nowLabel,
+  phaseLabel,
+  progress,
+  background,
+  isLoading = false,
+}: SunPathCardProps) {
+  if (isLoading) {
+    return (
+      <div>
+        <div className="h-6 w-24 animate-pulse rounded-md bg-muted/50" />
+        <div className="mt-6 h-16 w-full animate-pulse rounded-md bg-muted/50" />
+        <div className="mt-4 h-5 w-40 animate-pulse rounded-md bg-muted/50" />
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className="flex items-center justify-between text-sm text-muted-foreground">
+        <span>日の出/日の入り</span>
+        <span className="rounded-full bg-foreground/10 px-2 py-0.5 text-xs text-foreground">
+          {phaseLabel}
+        </span>
+      </div>
+      <div className="mt-4 rounded-2xl border border-foreground/10 p-4">
+        <div
+          className="relative h-24 w-full overflow-hidden rounded-xl"
+          style={{ background }}
+        >
+          <div className="absolute inset-0">
+            <svg
+              viewBox="0 0 300 120"
+              className="h-full w-full"
+              aria-hidden="true"
+            >
+              <path
+                d="M20 110 C 90 20, 210 20, 280 110"
+                fill="none"
+                stroke="rgba(255,255,255,0.5)"
+                strokeWidth="2"
+              />
+            </svg>
+          </div>
+          <div
+            className="absolute left-0 top-0 h-full w-full transition-transform duration-700"
+            style={{ transform: `translateX(${progress * 100}%)` }}
+          >
+            <div className="absolute left-0 top-1/2 -translate-y-1/2">
+              <div className="flex h-8 w-8 items-center justify-center rounded-full bg-white/90 text-sm shadow">
+                ☀️
+              </div>
+            </div>
+          </div>
+          <div className="absolute bottom-2 left-3 text-xs text-white/90">
+            {sunrise}
+          </div>
+          <div className="absolute bottom-2 right-3 text-xs text-white/90">
+            {sunset}
+          </div>
+        </div>
+        <div className="mt-3 flex items-center justify-between text-xs text-muted-foreground">
+          <span>現在 {nowLabel}</span>
+          <span>{Math.round(progress * 100)}%</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/lib/domain/sun-path.ts
+++ b/lib/domain/sun-path.ts
@@ -1,0 +1,66 @@
+type SunPhase = "night" | "dawn" | "day" | "dusk";
+
+const phases: Array<{
+  phase: SunPhase;
+  label: string;
+  background: string;
+}> = [
+  {
+    phase: "night",
+    label: "夜",
+    background: "linear-gradient(to bottom, #0f172a, #1e293b)",
+  },
+  {
+    phase: "dawn",
+    label: "朝焼け",
+    background: "linear-gradient(to bottom, #fca5a5, #fde68a)",
+  },
+  {
+    phase: "day",
+    label: "日中",
+    background: "linear-gradient(to bottom, #93c5fd, #e0f2fe)",
+  },
+  {
+    phase: "dusk",
+    label: "夕焼け",
+    background: "linear-gradient(to bottom, #fdba74, #f87171)",
+  },
+];
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max);
+}
+
+export function getSunProgress(now: Date, sunrise: Date, sunset: Date): number {
+  const nowTime = now.getTime();
+  const sunriseTime = sunrise.getTime();
+  const sunsetTime = sunset.getTime();
+
+  if (nowTime <= sunriseTime) return 0;
+  if (nowTime >= sunsetTime) return 1;
+
+  const progress = (nowTime - sunriseTime) / (sunsetTime - sunriseTime);
+  return clamp(progress, 0, 1);
+}
+
+export function getSunPhase(now: Date, sunrise: Date, sunset: Date): SunPhase {
+  const nowTime = now.getTime();
+  const sunriseTime = sunrise.getTime();
+  const sunsetTime = sunset.getTime();
+
+  if (nowTime < sunriseTime) return "night";
+  if (nowTime < sunriseTime + 60 * 60 * 1000) return "dawn";
+  if (nowTime < sunsetTime - 60 * 60 * 1000) return "day";
+  if (nowTime < sunsetTime) return "dusk";
+  return "night";
+}
+
+export function getSunPhaseLabel(phase: SunPhase): string {
+  const found = phases.find((item) => item.phase === phase);
+  return found?.label ?? "夜";
+}
+
+export function getSunPhaseBackground(phase: SunPhase): string {
+  const found = phases.find((item) => item.phase === phase);
+  return found?.background ?? phases[0].background;
+}


### PR DESCRIPTION
# 概要

日の出/日の入りの可視化カードを追加しました。

# 背景・目的

- Issue #70 の実装
- 時刻の流れをビジュアルで直感的に伝えるため

# 変更内容

- 日の出/日の入りの進行度と太陽軌道を表示するカードを追加
- トップ/比較ページにカードを配置
- 日中/夕方/夜などのフェーズ判定ロジックを追加

# 影響範囲

- `features/weather/ui/sun-path-card.tsx`
- `lib/domain/sun-path.ts`
- `app/page.tsx`
- `app/compare/page.tsx`

# テスト

- [ ] 未実施（理由）:
- [ ] 手動:
- [x] 自動: `pnpm typecheck`, `pnpm test`

# スクリーンショット

- [ ] 不要
- [ ] 添付

# 関連Issue

- Closes #70
