### PR TITLE
Issue #76: ページのViewModel化（天気派生データの分離）

### DIFF
--- a/features/weather/model/use-weather-snapshot.ts
+++ b/features/weather/model/use-weather-snapshot.ts
@@ -1,0 +1,95 @@
+import { useMemo } from "react";
+import type { WeatherDaily, WeatherHourly } from "@/lib/types/weather";
+import { getWeatherClassification } from "@/lib/domain/weather-classification";
+import { getUVClassification } from "@/lib/domain/uv-classification";
+import {
+  getWindDirectionLabel,
+  getWindDirectionRotation,
+} from "@/lib/domain/wind-direction";
+import {
+  getSunPhase,
+  getSunPhaseBackground,
+  getSunPhaseLabel,
+  getSunProgress,
+} from "@/lib/domain/sun-path";
+
+function findClosestIndex(times: string[]) {
+  const now = Date.now();
+  let bestIndex = 0;
+  let bestDiff = Number.POSITIVE_INFINITY;
+
+  times.forEach((time, index) => {
+    const value = new Date(time).getTime();
+    const diff = Math.abs(value - now);
+    if (diff < bestDiff) {
+      bestDiff = diff;
+      bestIndex = index;
+    }
+  });
+
+  return bestIndex;
+}
+
+type WeatherSnapshotInput = {
+  hourly: WeatherHourly | undefined;
+  daily: WeatherDaily | undefined;
+  timeZone: string;
+};
+
+export function useWeatherSnapshot({
+  hourly,
+  daily,
+  timeZone,
+}: WeatherSnapshotInput) {
+  return useMemo(() => {
+    if (!hourly) return undefined;
+    const index = findClosestIndex(hourly.time);
+    const snapshot = {
+      temperature: hourly.temperature_2m[index],
+      apparentTemperature: hourly.apparent_temperature[index],
+      humidity: hourly.relative_humidity_2m[index],
+      windSpeed: hourly.wind_speed_10m[index],
+      windDirection: hourly.wind_direction_10m[index],
+      weathercode: hourly.weathercode[index],
+      uvIndex: hourly.uv_index[index],
+      precipitationProbability: hourly.precipitation_probability[index],
+    };
+
+    const weatherClassification = getWeatherClassification(
+      snapshot.weathercode,
+    );
+    const uvClassification = getUVClassification(snapshot.uvIndex);
+    const uvIndexMax = daily?.uv_index_max?.[0];
+    const windDirectionLabel = getWindDirectionLabel(snapshot.windDirection);
+    const windDirectionRotation = getWindDirectionRotation(
+      snapshot.windDirection,
+    );
+    const sunriseAt = daily?.sunrise?.[0];
+    const sunsetAt = daily?.sunset?.[0];
+    const sunPhase =
+      sunriseAt && sunsetAt
+        ? getSunPhase(new Date(), new Date(sunriseAt), new Date(sunsetAt))
+        : "night";
+    const sunProgress =
+      sunriseAt && sunsetAt
+        ? getSunProgress(new Date(), new Date(sunriseAt), new Date(sunsetAt))
+        : 0;
+    const sunPhaseLabel = getSunPhaseLabel(sunPhase);
+    const sunPhaseBackground = getSunPhaseBackground(sunPhase);
+
+    return {
+      snapshot,
+      weatherClassification,
+      uvClassification,
+      uvIndexMax,
+      windDirectionLabel,
+      windDirectionRotation,
+      sunriseAt,
+      sunsetAt,
+      sunPhaseLabel,
+      sunPhaseBackground,
+      sunProgress,
+      timeZone,
+    };
+  }, [daily, hourly, timeZone]);
+}


### PR DESCRIPTION
# 概要

ページに集中していた天気系の派生計算をViewModel化し、責務分離を進めました。

# 背景・目的

- `app/page.tsx` / `app/compare/page.tsx` の責務が肥大化している
- 計算ロジックを `features/weather/model` に集約して見通しを良くしたい

# 変更内容

- `useWeatherSnapshot` を追加し、スナップショット/分類/サンパス計算を集約
- ページ側はViewModelの値を描画するだけに整理

# 影響範囲

- `features/weather/model/use-weather-snapshot.ts`
- `app/page.tsx`
- `app/compare/page.tsx`

# テスト

- [ ] 未実施（理由）:
- [ ] 手動:
- [x] 自動: `pnpm typecheck`, `pnpm test`

# スクリーンショット

- [ ] 不要
- [ ] 添付

# 関連Issue

- Closes #76
