### PR TITLE
Issue #78: ドメインテスト拡充（weather/uv/wind/sun）

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -7,15 +7,50 @@ import { ExternalLink } from "lucide-react";
 export default function AboutPage() {
   return (
     <div className="relative min-h-screen overflow-hidden">
-      {/* 背景グラデーション */}
+      {/* ノイズテクスチャ付きメッシュグラデーション */}
       <div className="fixed inset-0 -z-10">
+        {/* SVGノイズフィルター */}
+        <svg className="absolute h-0 w-0">
+          <filter id="noise-about">
+            <feTurbulence
+              type="fractalNoise"
+              baseFrequency="0.8"
+              numOctaves="4"
+              stitchTiles="stitch"
+            />
+            <feColorMatrix type="saturate" values="0" />
+            <feBlend mode="multiply" in="SourceGraphic" />
+          </filter>
+        </svg>
+
+        {/* 複数のグラデーションレイヤー - 紫〜青系の深い色合い */}
         <div
-          className="absolute inset-0"
+          className="absolute inset-0 opacity-60"
           style={{
-            background:
-              "radial-gradient(ellipse at 50% 30%, hsl(200, 80%, 45%) 0%, hsl(200, 60%, 25%) 30%, transparent 65%)",
+            background: `
+              radial-gradient(circle at 15% 25%, hsl(270, 75%, 50%) 0%, transparent 45%),
+              radial-gradient(circle at 75% 50%, hsl(220, 70%, 45%) 0%, transparent 50%),
+              radial-gradient(ellipse at 45% 85%, hsl(250, 65%, 40%) 0%, transparent 55%)
+            `,
           }}
         />
+        <div
+          className="absolute inset-0 opacity-35"
+          style={{
+            background: `
+              radial-gradient(circle at 55% 35%, hsl(190, 60%, 50%) 0%, transparent 40%),
+              radial-gradient(circle at 25% 75%, hsl(280, 55%, 45%) 0%, transparent 48%)
+            `,
+          }}
+        />
+
+        {/* ノイズテクスチャオーバーレイ */}
+        <div
+          className="absolute inset-0 opacity-[0.15] mix-blend-overlay"
+          style={{ filter: "url(#noise-about)" }}
+        />
+
+        {/* ベース背景 */}
         <div className="absolute inset-0 -z-10 bg-background" />
       </div>
 

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -22,23 +22,23 @@ export default function AboutPage() {
           </filter>
         </svg>
 
-        {/* 複数のグラデーションレイヤー - 深いグリーン〜アンバー〜チャコール */}
+        {/* Atmospheric Twilight: 大気の黄昏時の層を表現 */}
         <div
-          className="absolute inset-0 opacity-50"
+          className="absolute inset-0 opacity-55"
           style={{
             background: `
-              radial-gradient(circle at 15% 25%, hsl(160, 35%, 25%) 0%, transparent 45%),
-              radial-gradient(circle at 75% 50%, hsl(30, 40%, 28%) 0%, transparent 50%),
-              radial-gradient(ellipse at 45% 85%, hsl(25, 30%, 22%) 0%, transparent 55%)
+              radial-gradient(circle at 15% 20%, hsl(230, 35%, 15%) 0%, transparent 45%),
+              radial-gradient(ellipse at 80% 50%, hsl(260, 20%, 18%) 0%, transparent 50%),
+              radial-gradient(circle at 40% 85%, hsl(15, 45%, 22%) 0%, transparent 55%)
             `,
           }}
         />
         <div
-          className="absolute inset-0 opacity-30"
+          className="absolute inset-0 opacity-35"
           style={{
             background: `
-              radial-gradient(circle at 55% 35%, hsl(45, 35%, 30%) 0%, transparent 40%),
-              radial-gradient(circle at 25% 75%, hsl(0, 0%, 18%) 0%, transparent 48%)
+              radial-gradient(circle at 60% 30%, hsl(25, 15%, 12%) 0%, transparent 42%),
+              radial-gradient(ellipse at 20% 70%, hsl(230, 30%, 18%) 0%, transparent 48%)
             `,
           }}
         />

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -9,45 +9,53 @@ export default function AboutPage() {
     <div className="relative min-h-screen overflow-hidden">
       {/* ノイズテクスチャ付きメッシュグラデーション */}
       <div className="fixed inset-0 -z-10">
-        {/* SVGノイズフィルター */}
+        {/* SVGノイズフィルター（強化版） */}
         <svg className="absolute h-0 w-0">
           <filter id="noise-about">
             <feTurbulence
               type="fractalNoise"
-              baseFrequency="0.8"
-              numOctaves="4"
+              baseFrequency="0.9"
+              numOctaves="5"
               stitchTiles="stitch"
             />
             <feColorMatrix type="saturate" values="0" />
-            <feBlend mode="multiply" in="SourceGraphic" />
           </filter>
         </svg>
 
-        {/* 複数のグラデーションレイヤー - 紫〜青系の深い色合い */}
+        {/* 複数のグラデーションレイヤー - 深いグリーン〜アンバー〜チャコール */}
         <div
-          className="absolute inset-0 opacity-60"
+          className="absolute inset-0 opacity-50"
           style={{
             background: `
-              radial-gradient(circle at 15% 25%, hsl(270, 75%, 50%) 0%, transparent 45%),
-              radial-gradient(circle at 75% 50%, hsl(220, 70%, 45%) 0%, transparent 50%),
-              radial-gradient(ellipse at 45% 85%, hsl(250, 65%, 40%) 0%, transparent 55%)
+              radial-gradient(circle at 15% 25%, hsl(160, 35%, 25%) 0%, transparent 45%),
+              radial-gradient(circle at 75% 50%, hsl(30, 40%, 28%) 0%, transparent 50%),
+              radial-gradient(ellipse at 45% 85%, hsl(25, 30%, 22%) 0%, transparent 55%)
             `,
           }}
         />
         <div
-          className="absolute inset-0 opacity-35"
+          className="absolute inset-0 opacity-30"
           style={{
             background: `
-              radial-gradient(circle at 55% 35%, hsl(190, 60%, 50%) 0%, transparent 40%),
-              radial-gradient(circle at 25% 75%, hsl(280, 55%, 45%) 0%, transparent 48%)
+              radial-gradient(circle at 55% 35%, hsl(45, 35%, 30%) 0%, transparent 40%),
+              radial-gradient(circle at 25% 75%, hsl(0, 0%, 18%) 0%, transparent 48%)
             `,
           }}
         />
 
-        {/* ノイズテクスチャオーバーレイ */}
+        {/* ノイズテクスチャオーバーレイ（強化） */}
         <div
-          className="absolute inset-0 opacity-[0.15] mix-blend-overlay"
+          className="absolute inset-0 opacity-[0.35] mix-blend-soft-light"
           style={{ filter: "url(#noise-about)" }}
+        />
+
+        {/* ビネット効果（周辺を暗く） */}
+        <div
+          className="absolute inset-0"
+          style={{
+            background:
+              "radial-gradient(ellipse at center, transparent 0%, rgba(0, 0, 0, 0.3) 100%)",
+          }}
         />
 
         {/* ベース背景 */}

--- a/app/compare/page.tsx
+++ b/app/compare/page.tsx
@@ -61,29 +61,76 @@ export default function ComparePage() {
   );
   return (
     <div className="relative min-h-screen overflow-hidden">
-      {/* データドリブンな背景グラデーション */}
+      {/* ノイズテクスチャ付きメッシュグラデーション */}
       <div className="fixed inset-0 -z-10">
-        {/* 左側のグラデーション */}
+        {/* SVGノイズフィルター */}
+        <svg className="absolute h-0 w-0">
+          <filter id="noise-compare">
+            <feTurbulence
+              type="fractalNoise"
+              baseFrequency="0.8"
+              numOctaves="4"
+              stitchTiles="stitch"
+            />
+            <feColorMatrix type="saturate" values="0" />
+            <feBlend mode="multiply" in="SourceGraphic" />
+          </filter>
+        </svg>
+
+        {/* 左側の都市：複数のグラデーションレイヤー */}
         <div
-          className="absolute left-0 top-0 h-full w-1/2 transition-all duration-1000"
+          className="absolute left-0 top-0 h-full w-1/2 opacity-60 transition-all duration-1000"
           style={{
-            background: `radial-gradient(ellipse at 20% 50%, hsl(${leftBgColor}, 40%) 0%, hsl(${leftBgColor}, 20%) 40%, transparent 70%)`,
+            background: `
+              radial-gradient(circle at 15% 20%, hsl(${leftBgColor}, 55%) 0%, transparent 45%),
+              radial-gradient(circle at 35% 65%, hsl(${leftBgColor}, 45%) 0%, transparent 50%),
+              radial-gradient(ellipse at 10% 80%, hsl(${leftBgColor}, 35%) 0%, transparent 55%)
+            `,
           }}
         />
-        {/* 右側のグラデーション */}
         <div
-          className="absolute right-0 top-0 h-full w-1/2 transition-all duration-1000"
+          className="absolute left-0 top-0 h-full w-1/2 opacity-35 transition-all duration-1000"
           style={{
-            background: `radial-gradient(ellipse at 80% 50%, hsl(${rightBgColor}, 40%) 0%, hsl(${rightBgColor}, 20%) 40%, transparent 70%)`,
+            background: `
+              radial-gradient(circle at 25% 45%, hsl(${(parseInt(leftBgColor.split(" ")[0]) + 25) % 360} ${leftBgColor.split(" ")[1]} ${leftBgColor.split(" ")[2]}, 40%) 0%, transparent 42%)
+            `,
           }}
         />
-        {/* 中央のブレンド */}
+
+        {/* 右側の都市：複数のグラデーションレイヤー */}
         <div
-          className="absolute left-1/2 top-0 h-full w-1/3 -translate-x-1/2 opacity-30 blur-3xl"
+          className="absolute right-0 top-0 h-full w-1/2 opacity-60 transition-all duration-1000"
           style={{
-            background: `linear-gradient(135deg, hsl(${leftBgColor}, 30%), hsl(${rightBgColor}, 30%))`,
+            background: `
+              radial-gradient(circle at 85% 20%, hsl(${rightBgColor}, 55%) 0%, transparent 45%),
+              radial-gradient(circle at 65% 65%, hsl(${rightBgColor}, 45%) 0%, transparent 50%),
+              radial-gradient(ellipse at 90% 80%, hsl(${rightBgColor}, 35%) 0%, transparent 55%)
+            `,
           }}
         />
+        <div
+          className="absolute right-0 top-0 h-full w-1/2 opacity-35 transition-all duration-1000"
+          style={{
+            background: `
+              radial-gradient(circle at 75% 45%, hsl(${(parseInt(rightBgColor.split(" ")[0]) + 25) % 360} ${rightBgColor.split(" ")[1]} ${rightBgColor.split(" ")[2]}, 40%) 0%, transparent 42%)
+            `,
+          }}
+        />
+
+        {/* 中央のブレンドゾーン */}
+        <div
+          className="absolute left-1/2 top-0 h-full w-1/3 -translate-x-1/2 opacity-25 blur-3xl transition-all duration-1000"
+          style={{
+            background: `linear-gradient(135deg, hsl(${leftBgColor}, 35%), hsl(${rightBgColor}, 35%))`,
+          }}
+        />
+
+        {/* ノイズテクスチャオーバーレイ */}
+        <div
+          className="absolute inset-0 opacity-[0.15] mix-blend-overlay"
+          style={{ filter: "url(#noise-compare)" }}
+        />
+
         {/* ベース背景 */}
         <div className="absolute inset-0 -z-10 bg-background" />
       </div>

--- a/app/compare/page.tsx
+++ b/app/compare/page.tsx
@@ -63,72 +63,80 @@ export default function ComparePage() {
     <div className="relative min-h-screen overflow-hidden">
       {/* ノイズテクスチャ付きメッシュグラデーション */}
       <div className="fixed inset-0 -z-10">
-        {/* SVGノイズフィルター */}
+        {/* SVGノイズフィルター（強化版） */}
         <svg className="absolute h-0 w-0">
           <filter id="noise-compare">
             <feTurbulence
               type="fractalNoise"
-              baseFrequency="0.8"
-              numOctaves="4"
+              baseFrequency="0.9"
+              numOctaves="5"
               stitchTiles="stitch"
             />
             <feColorMatrix type="saturate" values="0" />
-            <feBlend mode="multiply" in="SourceGraphic" />
           </filter>
         </svg>
 
-        {/* 左側の都市：複数のグラデーションレイヤー */}
+        {/* 左側の都市：複数のグラデーションレイヤー（彩度を抑えて高級感） */}
         <div
-          className="absolute left-0 top-0 h-full w-1/2 opacity-60 transition-all duration-1000"
+          className="absolute left-0 top-0 h-full w-1/2 opacity-50 transition-all duration-1000"
           style={{
             background: `
-              radial-gradient(circle at 15% 20%, hsl(${leftBgColor}, 55%) 0%, transparent 45%),
-              radial-gradient(circle at 35% 65%, hsl(${leftBgColor}, 45%) 0%, transparent 50%),
-              radial-gradient(ellipse at 10% 80%, hsl(${leftBgColor}, 35%) 0%, transparent 55%)
+              radial-gradient(circle at 15% 20%, hsl(${leftBgColor}, 28%) 0%, transparent 45%),
+              radial-gradient(circle at 35% 65%, hsl(${leftBgColor}, 22%) 0%, transparent 50%),
+              radial-gradient(ellipse at 10% 80%, hsl(${leftBgColor}, 18%) 0%, transparent 55%)
             `,
           }}
         />
         <div
-          className="absolute left-0 top-0 h-full w-1/2 opacity-35 transition-all duration-1000"
+          className="absolute left-0 top-0 h-full w-1/2 opacity-30 transition-all duration-1000"
           style={{
             background: `
-              radial-gradient(circle at 25% 45%, hsl(${(parseInt(leftBgColor.split(" ")[0]) + 25) % 360} ${leftBgColor.split(" ")[1]} ${leftBgColor.split(" ")[2]}, 40%) 0%, transparent 42%)
+              radial-gradient(circle at 25% 45%, hsl(${(parseInt(leftBgColor.split(" ")[0]) + 25) % 360} ${leftBgColor.split(" ")[1]} ${leftBgColor.split(" ")[2]}, 20%) 0%, transparent 42%)
             `,
           }}
         />
 
-        {/* 右側の都市：複数のグラデーションレイヤー */}
+        {/* 右側の都市：複数のグラデーションレイヤー（彩度を抑えて高級感） */}
         <div
-          className="absolute right-0 top-0 h-full w-1/2 opacity-60 transition-all duration-1000"
+          className="absolute right-0 top-0 h-full w-1/2 opacity-50 transition-all duration-1000"
           style={{
             background: `
-              radial-gradient(circle at 85% 20%, hsl(${rightBgColor}, 55%) 0%, transparent 45%),
-              radial-gradient(circle at 65% 65%, hsl(${rightBgColor}, 45%) 0%, transparent 50%),
-              radial-gradient(ellipse at 90% 80%, hsl(${rightBgColor}, 35%) 0%, transparent 55%)
+              radial-gradient(circle at 85% 20%, hsl(${rightBgColor}, 28%) 0%, transparent 45%),
+              radial-gradient(circle at 65% 65%, hsl(${rightBgColor}, 22%) 0%, transparent 50%),
+              radial-gradient(ellipse at 90% 80%, hsl(${rightBgColor}, 18%) 0%, transparent 55%)
             `,
           }}
         />
         <div
-          className="absolute right-0 top-0 h-full w-1/2 opacity-35 transition-all duration-1000"
+          className="absolute right-0 top-0 h-full w-1/2 opacity-30 transition-all duration-1000"
           style={{
             background: `
-              radial-gradient(circle at 75% 45%, hsl(${(parseInt(rightBgColor.split(" ")[0]) + 25) % 360} ${rightBgColor.split(" ")[1]} ${rightBgColor.split(" ")[2]}, 40%) 0%, transparent 42%)
+              radial-gradient(circle at 75% 45%, hsl(${(parseInt(rightBgColor.split(" ")[0]) + 25) % 360} ${rightBgColor.split(" ")[1]} ${rightBgColor.split(" ")[2]}, 20%) 0%, transparent 42%)
             `,
           }}
         />
 
         {/* 中央のブレンドゾーン */}
         <div
-          className="absolute left-1/2 top-0 h-full w-1/3 -translate-x-1/2 opacity-25 blur-3xl transition-all duration-1000"
+          className="absolute left-1/2 top-0 h-full w-1/3 -translate-x-1/2 opacity-20 blur-3xl transition-all duration-1000"
           style={{
-            background: `linear-gradient(135deg, hsl(${leftBgColor}, 35%), hsl(${rightBgColor}, 35%))`,
+            background: `linear-gradient(135deg, hsl(${leftBgColor}, 18%), hsl(${rightBgColor}, 18%))`,
           }}
         />
 
-        {/* ノイズテクスチャオーバーレイ */}
+        {/* ノイズテクスチャオーバーレイ（強化） */}
         <div
-          className="absolute inset-0 opacity-[0.15] mix-blend-overlay"
+          className="absolute inset-0 opacity-[0.35] mix-blend-soft-light"
           style={{ filter: "url(#noise-compare)" }}
+        />
+
+        {/* ビネット効果（周辺を暗く） */}
+        <div
+          className="absolute inset-0"
+          style={{
+            background:
+              "radial-gradient(ellipse at center, transparent 0%, rgba(0, 0, 0, 0.3) 100%)",
+          }}
         />
 
         {/* ベース背景 */}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -47,14 +47,50 @@ export default function Home() {
   const bgColor = temperatureToColor(weatherView?.snapshot.temperature ?? 20);
   return (
     <div className="relative min-h-screen overflow-hidden">
-      {/* データドリブンな背景グラデーション */}
+      {/* ノイズテクスチャ付きメッシュグラデーション */}
       <div className="fixed inset-0 -z-10">
+        {/* SVGノイズフィルター */}
+        <svg className="absolute h-0 w-0">
+          <filter id="noise">
+            <feTurbulence
+              type="fractalNoise"
+              baseFrequency="0.8"
+              numOctaves="4"
+              stitchTiles="stitch"
+            />
+            <feColorMatrix type="saturate" values="0" />
+            <feBlend mode="multiply" in="SourceGraphic" />
+          </filter>
+        </svg>
+
+        {/* 複数のグラデーションレイヤー */}
         <div
-          className="absolute inset-0 transition-all duration-1000"
+          className="absolute inset-0 opacity-60 transition-all duration-1000"
           style={{
-            background: `radial-gradient(ellipse at 50% 30%, hsl(${bgColor}, 45%) 0%, hsl(${bgColor}, 25%) 30%, transparent 65%)`,
+            background: `
+              radial-gradient(circle at 20% 20%, hsl(${bgColor}, 55%) 0%, transparent 50%),
+              radial-gradient(circle at 80% 60%, hsl(${bgColor}, 45%) 0%, transparent 50%),
+              radial-gradient(ellipse at 50% 80%, hsl(${bgColor}, 35%) 0%, transparent 60%)
+            `,
           }}
         />
+        <div
+          className="absolute inset-0 opacity-40 transition-all duration-1000"
+          style={{
+            background: `
+              radial-gradient(circle at 60% 40%, hsl(${(parseInt(bgColor.split(" ")[0]) + 30) % 360} ${bgColor.split(" ")[1]} ${bgColor.split(" ")[2]}, 40%) 0%, transparent 45%),
+              radial-gradient(circle at 30% 70%, hsl(${(parseInt(bgColor.split(" ")[0]) - 20) % 360} ${bgColor.split(" ")[1]} ${bgColor.split(" ")[2]}, 35%) 0%, transparent 50%)
+            `,
+          }}
+        />
+
+        {/* ノイズテクスチャオーバーレイ */}
+        <div
+          className="absolute inset-0 opacity-[0.15] mix-blend-overlay"
+          style={{ filter: "url(#noise)" }}
+        />
+
+        {/* ベース背景 */}
         <div className="absolute inset-0 -z-10 bg-background" />
       </div>
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -49,45 +49,53 @@ export default function Home() {
     <div className="relative min-h-screen overflow-hidden">
       {/* ノイズテクスチャ付きメッシュグラデーション */}
       <div className="fixed inset-0 -z-10">
-        {/* SVGノイズフィルター */}
+        {/* SVGノイズフィルター（強化版） */}
         <svg className="absolute h-0 w-0">
           <filter id="noise">
             <feTurbulence
               type="fractalNoise"
-              baseFrequency="0.8"
-              numOctaves="4"
+              baseFrequency="0.9"
+              numOctaves="5"
               stitchTiles="stitch"
             />
             <feColorMatrix type="saturate" values="0" />
-            <feBlend mode="multiply" in="SourceGraphic" />
           </filter>
         </svg>
 
-        {/* 複数のグラデーションレイヤー */}
+        {/* 複数のグラデーションレイヤー（彩度を抑えて高級感） */}
         <div
-          className="absolute inset-0 opacity-60 transition-all duration-1000"
+          className="absolute inset-0 opacity-50 transition-all duration-1000"
           style={{
             background: `
-              radial-gradient(circle at 20% 20%, hsl(${bgColor}, 55%) 0%, transparent 50%),
-              radial-gradient(circle at 80% 60%, hsl(${bgColor}, 45%) 0%, transparent 50%),
-              radial-gradient(ellipse at 50% 80%, hsl(${bgColor}, 35%) 0%, transparent 60%)
+              radial-gradient(circle at 20% 20%, hsl(${bgColor}, 28%) 0%, transparent 50%),
+              radial-gradient(circle at 80% 60%, hsl(${bgColor}, 22%) 0%, transparent 50%),
+              radial-gradient(ellipse at 50% 80%, hsl(${bgColor}, 18%) 0%, transparent 60%)
             `,
           }}
         />
         <div
-          className="absolute inset-0 opacity-40 transition-all duration-1000"
+          className="absolute inset-0 opacity-30 transition-all duration-1000"
           style={{
             background: `
-              radial-gradient(circle at 60% 40%, hsl(${(parseInt(bgColor.split(" ")[0]) + 30) % 360} ${bgColor.split(" ")[1]} ${bgColor.split(" ")[2]}, 40%) 0%, transparent 45%),
-              radial-gradient(circle at 30% 70%, hsl(${(parseInt(bgColor.split(" ")[0]) - 20) % 360} ${bgColor.split(" ")[1]} ${bgColor.split(" ")[2]}, 35%) 0%, transparent 50%)
+              radial-gradient(circle at 60% 40%, hsl(${(parseInt(bgColor.split(" ")[0]) + 30) % 360} ${bgColor.split(" ")[1]} ${bgColor.split(" ")[2]}, 20%) 0%, transparent 45%),
+              radial-gradient(circle at 30% 70%, hsl(${(parseInt(bgColor.split(" ")[0]) - 20) % 360} ${bgColor.split(" ")[1]} ${bgColor.split(" ")[2]}, 16%) 0%, transparent 50%)
             `,
           }}
         />
 
-        {/* ノイズテクスチャオーバーレイ */}
+        {/* ノイズテクスチャオーバーレイ（強化） */}
         <div
-          className="absolute inset-0 opacity-[0.15] mix-blend-overlay"
+          className="absolute inset-0 opacity-[0.35] mix-blend-soft-light"
           style={{ filter: "url(#noise)" }}
+        />
+
+        {/* ビネット効果（周辺を暗く） */}
+        <div
+          className="absolute inset-0"
+          style={{
+            background:
+              "radial-gradient(ellipse at center, transparent 0%, rgba(0, 0, 0, 0.3) 100%)",
+          }}
         />
 
         {/* ベース背景 */}

--- a/tests/unit/domain/sun-path.test.ts
+++ b/tests/unit/domain/sun-path.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import {
+  getSunPhase,
+  getSunPhaseBackground,
+  getSunPhaseLabel,
+  getSunProgress,
+} from "@/lib/domain/sun-path";
+
+describe("getSunProgress", () => {
+  it("returns 0 before sunrise", () => {
+    const sunrise = new Date("2025-01-01T06:00:00Z");
+    const sunset = new Date("2025-01-01T18:00:00Z");
+    const now = new Date("2025-01-01T05:00:00Z");
+    expect(getSunProgress(now, sunrise, sunset)).toBe(0);
+  });
+
+  it("returns 1 after sunset", () => {
+    const sunrise = new Date("2025-01-01T06:00:00Z");
+    const sunset = new Date("2025-01-01T18:00:00Z");
+    const now = new Date("2025-01-01T19:00:00Z");
+    expect(getSunProgress(now, sunrise, sunset)).toBe(1);
+  });
+
+  it("returns mid progress at midday", () => {
+    const sunrise = new Date("2025-01-01T06:00:00Z");
+    const sunset = new Date("2025-01-01T18:00:00Z");
+    const now = new Date("2025-01-01T12:00:00Z");
+    expect(getSunProgress(now, sunrise, sunset)).toBeCloseTo(0.5, 2);
+  });
+});
+
+describe("getSunPhase", () => {
+  it("returns night before sunrise", () => {
+    const sunrise = new Date("2025-01-01T06:00:00Z");
+    const sunset = new Date("2025-01-01T18:00:00Z");
+    const now = new Date("2025-01-01T05:30:00Z");
+    expect(getSunPhase(now, sunrise, sunset)).toBe("night");
+  });
+
+  it("returns dawn just after sunrise", () => {
+    const sunrise = new Date("2025-01-01T06:00:00Z");
+    const sunset = new Date("2025-01-01T18:00:00Z");
+    const now = new Date("2025-01-01T06:30:00Z");
+    expect(getSunPhase(now, sunrise, sunset)).toBe("dawn");
+  });
+
+  it("returns day in the middle", () => {
+    const sunrise = new Date("2025-01-01T06:00:00Z");
+    const sunset = new Date("2025-01-01T18:00:00Z");
+    const now = new Date("2025-01-01T12:00:00Z");
+    expect(getSunPhase(now, sunrise, sunset)).toBe("day");
+  });
+
+  it("returns dusk before sunset", () => {
+    const sunrise = new Date("2025-01-01T06:00:00Z");
+    const sunset = new Date("2025-01-01T18:00:00Z");
+    const now = new Date("2025-01-01T17:30:00Z");
+    expect(getSunPhase(now, sunrise, sunset)).toBe("dusk");
+  });
+});
+
+describe("getSunPhaseLabel/background", () => {
+  it("returns label and background for night", () => {
+    expect(getSunPhaseLabel("night")).toBe("夜");
+    expect(getSunPhaseBackground("night")).toContain("#0f172a");
+  });
+});

--- a/tests/unit/domain/uv-classification.test.ts
+++ b/tests/unit/domain/uv-classification.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import {
+  classifyUVIndex,
+  getUVClassification,
+} from "@/lib/domain/uv-classification";
+
+describe("classifyUVIndex", () => {
+  it("classifies low range", () => {
+    expect(classifyUVIndex(0)).toBe("low");
+    expect(classifyUVIndex(2)).toBe("low");
+  });
+
+  it("classifies moderate range", () => {
+    expect(classifyUVIndex(3)).toBe("moderate");
+    expect(classifyUVIndex(5)).toBe("moderate");
+  });
+
+  it("classifies high range", () => {
+    expect(classifyUVIndex(6)).toBe("high");
+    expect(classifyUVIndex(7)).toBe("high");
+  });
+
+  it("classifies very-high range", () => {
+    expect(classifyUVIndex(8)).toBe("very-high");
+    expect(classifyUVIndex(10)).toBe("very-high");
+  });
+
+  it("classifies extreme range", () => {
+    expect(classifyUVIndex(11)).toBe("extreme");
+    expect(classifyUVIndex(20)).toBe("extreme");
+  });
+});
+
+describe("getUVClassification", () => {
+  it("returns label and color", () => {
+    const classification = getUVClassification(6.5);
+    expect(classification.label).toBe("高い");
+    expect(classification.color).toContain("hsl");
+  });
+});

--- a/tests/unit/domain/weather-classification.test.ts
+++ b/tests/unit/domain/weather-classification.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import {
+  getWeatherClassification,
+  getWeatherCondition,
+} from "@/lib/domain/weather-classification";
+
+describe("getWeatherCondition", () => {
+  it("returns clear for code 0", () => {
+    expect(getWeatherCondition(0)).toBe("clear");
+  });
+
+  it("returns rain for range 61-65", () => {
+    expect(getWeatherCondition(61)).toBe("rain");
+    expect(getWeatherCondition(63)).toBe("rain");
+    expect(getWeatherCondition(65)).toBe("rain");
+  });
+
+  it("returns snow-showers for 85-86", () => {
+    expect(getWeatherCondition(85)).toBe("snow-showers");
+    expect(getWeatherCondition(86)).toBe("snow-showers");
+  });
+
+  it("returns thunderstorm for 95-99", () => {
+    expect(getWeatherCondition(95)).toBe("thunderstorm");
+    expect(getWeatherCondition(99)).toBe("thunderstorm");
+  });
+
+  it("returns unknown for unsupported code", () => {
+    expect(getWeatherCondition(999)).toBe("unknown");
+  });
+});
+
+describe("getWeatherClassification", () => {
+  it("returns label and icon for known code", () => {
+    const classification = getWeatherClassification(2);
+    expect(classification.label).toBe("薄曇り");
+    expect(classification.iconKey).toBe("cloud-sun");
+  });
+});

--- a/tests/unit/domain/wind-direction.test.ts
+++ b/tests/unit/domain/wind-direction.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import {
+  getWindDirectionLabel,
+  getWindDirectionRotation,
+} from "@/lib/domain/wind-direction";
+
+describe("getWindDirectionLabel", () => {
+  it("returns north for 0 degrees", () => {
+    expect(getWindDirectionLabel(0)).toBe("北");
+  });
+
+  it("returns east for 90 degrees", () => {
+    expect(getWindDirectionLabel(90)).toBe("東");
+  });
+
+  it("returns south for 180 degrees", () => {
+    expect(getWindDirectionLabel(180)).toBe("南");
+  });
+
+  it("normalizes negative degrees", () => {
+    expect(getWindDirectionLabel(-10)).toBe("北");
+  });
+});
+
+describe("getWindDirectionRotation", () => {
+  it("normalizes degrees to 0-359", () => {
+    expect(getWindDirectionRotation(360)).toBe(0);
+    expect(getWindDirectionRotation(450)).toBe(90);
+  });
+});


### PR DESCRIPTION
# 概要

天気/UV/風向き/サンパスのドメインロジックにユニットテストを追加しました。

# 背景・目的

- 新規ドメインロジックの回帰リスクを下げるため
- 境界値の挙動を明確にするため

# 変更内容

- `weather-classification` の分類テスト追加
- `uv-classification` の境界値テスト追加
- `wind-direction` の方位/正規化テスト追加
- `sun-path` の進行度/フェーズ判定テスト追加

# 影響範囲

- `tests/unit/domain/weather-classification.test.ts`
- `tests/unit/domain/uv-classification.test.ts`
- `tests/unit/domain/wind-direction.test.ts`
- `tests/unit/domain/sun-path.test.ts`

# テスト

- [ ] 未実施（理由）:
- [ ] 手動:
- [x] 自動: `pnpm typecheck`, `pnpm test`

# スクリーンショット

- [ ] 不要
- [ ] 添付

# 関連Issue

- Closes #78
