### PR TITLE
Issue #84: 天気データのタイムゾーン補正

### DIFF
--- a/app/compare/page.tsx
+++ b/app/compare/page.tsx
@@ -36,11 +36,13 @@ export default function ComparePage() {
     hourly: leftWeather.data?.hourly,
     daily: leftWeather.data?.daily,
     timeZone: leftWeather.data?.timezone ?? leftCity.timezone,
+    utcOffsetSeconds: leftWeather.data?.utc_offset_seconds,
   });
   const rightWeatherView = useWeatherSnapshot({
     hourly: rightWeather.data?.hourly,
     daily: rightWeather.data?.daily,
     timeZone: rightWeather.data?.timezone ?? rightCity.timezone,
+    utcOffsetSeconds: rightWeather.data?.utc_offset_seconds,
   });
 
   const leftAirSeries = useMemo(
@@ -316,19 +318,19 @@ export default function ComparePage() {
             {leftWeatherView?.sunriseAt && leftWeatherView.sunsetAt ? (
               <div className="group rounded-3xl border border-foreground/10 bg-background/50 p-6 backdrop-blur-2xl transition-all duration-300 hover:border-foreground/20 hover:bg-background/60 hover:shadow-2xl hover:-translate-y-1">
                 <SunPathCard
-                  sunrise={new Date(
-                    leftWeatherView.sunriseAt,
-                  ).toLocaleTimeString("ja-JP", {
-                    hour: "2-digit",
-                    minute: "2-digit",
-                  })}
-                  sunset={new Date(leftWeatherView.sunsetAt).toLocaleTimeString(
+                  sunrise={leftWeatherView.sunriseAt.toLocaleTimeString(
                     "ja-JP",
                     {
                       hour: "2-digit",
                       minute: "2-digit",
+                      timeZone: leftWeatherView.timeZone,
                     },
                   )}
+                  sunset={leftWeatherView.sunsetAt.toLocaleTimeString("ja-JP", {
+                    hour: "2-digit",
+                    minute: "2-digit",
+                    timeZone: leftWeatherView.timeZone,
+                  })}
                   nowLabel={formatLocalTime(leftCity.timezone)}
                   phaseLabel={leftWeatherView.sunPhaseLabel}
                   progress={leftWeatherView.sunProgress}
@@ -347,6 +349,7 @@ export default function ComparePage() {
                   data={leftWeather.data.hourly}
                   dataKey="temperature_2m"
                   timeZone={leftWeather.data.timezone}
+                  utcOffsetSeconds={leftWeather.data.utc_offset_seconds}
                 />
               </div>
             ) : (
@@ -433,18 +436,22 @@ export default function ComparePage() {
             {rightWeatherView?.sunriseAt && rightWeatherView.sunsetAt ? (
               <div className="group rounded-3xl border border-foreground/10 bg-background/50 p-6 backdrop-blur-2xl transition-all duration-300 hover:border-foreground/20 hover:bg-background/60 hover:shadow-2xl hover:-translate-y-1">
                 <SunPathCard
-                  sunrise={new Date(
-                    rightWeatherView.sunriseAt,
-                  ).toLocaleTimeString("ja-JP", {
-                    hour: "2-digit",
-                    minute: "2-digit",
-                  })}
-                  sunset={new Date(
-                    rightWeatherView.sunsetAt,
-                  ).toLocaleTimeString("ja-JP", {
-                    hour: "2-digit",
-                    minute: "2-digit",
-                  })}
+                  sunrise={rightWeatherView.sunriseAt.toLocaleTimeString(
+                    "ja-JP",
+                    {
+                      hour: "2-digit",
+                      minute: "2-digit",
+                      timeZone: rightWeatherView.timeZone,
+                    },
+                  )}
+                  sunset={rightWeatherView.sunsetAt.toLocaleTimeString(
+                    "ja-JP",
+                    {
+                      hour: "2-digit",
+                      minute: "2-digit",
+                      timeZone: rightWeatherView.timeZone,
+                    },
+                  )}
                   nowLabel={formatLocalTime(rightCity.timezone)}
                   phaseLabel={rightWeatherView.sunPhaseLabel}
                   progress={rightWeatherView.sunProgress}
@@ -463,6 +470,7 @@ export default function ComparePage() {
                   data={rightWeather.data.hourly}
                   dataKey="temperature_2m"
                   timeZone={rightWeather.data.timezone}
+                  utcOffsetSeconds={rightWeather.data.utc_offset_seconds}
                 />
               </div>
             ) : (

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -36,6 +36,7 @@ export default function Home() {
     hourly: weatherQuery.data?.hourly,
     daily: weatherQuery.data?.daily,
     timeZone: weatherQuery.data?.timezone ?? activeCity.timezone,
+    utcOffsetSeconds: weatherQuery.data?.utc_offset_seconds,
   });
 
   const airSeries = useMemo(
@@ -213,20 +214,16 @@ export default function Home() {
             {weatherView?.sunriseAt && weatherView.sunsetAt ? (
               <div className="group rounded-3xl border border-foreground/10 bg-background/50 p-6 backdrop-blur-2xl transition-all duration-300 hover:border-foreground/20 hover:bg-background/60 hover:shadow-2xl hover:-translate-y-1">
                 <SunPathCard
-                  sunrise={new Date(weatherView.sunriseAt).toLocaleTimeString(
-                    "ja-JP",
-                    {
-                      hour: "2-digit",
-                      minute: "2-digit",
-                    },
-                  )}
-                  sunset={new Date(weatherView.sunsetAt).toLocaleTimeString(
-                    "ja-JP",
-                    {
-                      hour: "2-digit",
-                      minute: "2-digit",
-                    },
-                  )}
+                  sunrise={weatherView.sunriseAt.toLocaleTimeString("ja-JP", {
+                    hour: "2-digit",
+                    minute: "2-digit",
+                    timeZone: weatherView.timeZone,
+                  })}
+                  sunset={weatherView.sunsetAt.toLocaleTimeString("ja-JP", {
+                    hour: "2-digit",
+                    minute: "2-digit",
+                    timeZone: weatherView.timeZone,
+                  })}
                   nowLabel={formatLocalTime(activeCity.timezone)}
                   phaseLabel={weatherView.sunPhaseLabel}
                   progress={weatherView.sunProgress}
@@ -245,6 +242,7 @@ export default function Home() {
                   data={weatherQuery.data.hourly}
                   dataKey="temperature_2m"
                   timeZone={weatherQuery.data.timezone}
+                  utcOffsetSeconds={weatherQuery.data.utc_offset_seconds}
                 />
               </div>
             ) : (

--- a/features/weather/ui/weather-chart-client.tsx
+++ b/features/weather/ui/weather-chart-client.tsx
@@ -11,6 +11,7 @@ import {
 } from "recharts";
 import type { WeatherDaily, WeatherHourly } from "@/lib/types/weather";
 import { cn } from "@/lib/utils";
+import { toUtcDateFromLocalTime } from "@/lib/utils/timezone";
 
 type HourlyKey =
   | "temperature_2m"
@@ -27,6 +28,7 @@ type DailyKey =
 type BaseChartProps = {
   title?: string;
   timeZone?: string;
+  utcOffsetSeconds?: number;
   onRangeChange?: (range: "24h" | "7d") => void;
 };
 
@@ -51,8 +53,10 @@ function formatTimeLabel(
   value: string,
   range: "24h" | "7d",
   timeZone?: string,
+  utcOffsetSeconds?: number,
 ) {
-  const date = new Date(value);
+  const date = toUtcDateFromLocalTime(value, utcOffsetSeconds);
+  if (!date) return value;
   if (Number.isNaN(date.getTime())) return value;
 
   const options: Intl.DateTimeFormatOptions =
@@ -72,6 +76,7 @@ export function WeatherChart({
   dataKey,
   title,
   timeZone,
+  utcOffsetSeconds,
   onRangeChange,
 }: WeatherChartProps) {
   const chartData = useMemo<ChartPoint[]>(() => {
@@ -82,10 +87,10 @@ export function WeatherChart({
         : (data as WeatherDaily)[dataKey as DailyKey];
 
     return times.map((time, index) => ({
-      time: formatTimeLabel(time, range, timeZone),
+      time: formatTimeLabel(time, range, timeZone, utcOffsetSeconds),
       value: values[index] ?? 0,
     }));
-  }, [data, dataKey, range, timeZone]);
+  }, [data, dataKey, range, timeZone, utcOffsetSeconds]);
 
   return (
     <div>

--- a/lib/types/weather.ts
+++ b/lib/types/weather.ts
@@ -25,6 +25,7 @@ export type WeatherResponse = {
   latitude: number;
   longitude: number;
   timezone: string;
+  utc_offset_seconds: number;
   hourly?: WeatherHourly;
   daily?: WeatherDaily;
 };

--- a/lib/utils/timezone.ts
+++ b/lib/utils/timezone.ts
@@ -1,0 +1,9 @@
+export function toUtcDateFromLocalTime(
+  value: string,
+  utcOffsetSeconds?: number,
+) {
+  const timestamp = Date.parse(`${value}Z`);
+  if (Number.isNaN(timestamp)) return undefined;
+  const offsetMs = (utcOffsetSeconds ?? 0) * 1000;
+  return new Date(timestamp - offsetMs);
+}

--- a/lib/validators/weather.ts
+++ b/lib/validators/weather.ts
@@ -27,6 +27,7 @@ export const WeatherResponseSchema = z.object({
   latitude: z.number(),
   longitude: z.number(),
   timezone: z.string(),
+  utc_offset_seconds: z.number(),
   hourly: WeatherHourlySchema.optional(),
   daily: WeatherDailySchema.optional(),
 });


### PR DESCRIPTION
# 概要

天気データの時刻を `utc_offset_seconds` を使って解釈し、都市のタイムゾーンに合わせた表示に修正しました。

# 背景・目的

- 都市のタイムゾーンと表示時刻がずれる問題を解消するため

# 変更内容

- `utc_offset_seconds` を型/バリデーションに追加
- 天気スナップショットとチャートの時刻計算を補正
- 日の出/日の入りの表示を都市タイムゾーンで整合

# 影響範囲

- `features/weather/model/use-weather-snapshot.ts`
- `features/weather/ui/weather-chart-client.tsx`
- `app/page.tsx`
- `app/compare/page.tsx`
- `lib/types/weather.ts`
- `lib/validators/weather.ts`
- `lib/utils/timezone.ts`

# テスト

- [ ] 未実施（理由）:
- [ ] 手動:
- [x] 自動: `pnpm test` / `pnpm typecheck` (pre-push)

# スクリーンショット

- [x] 不要
- [ ] 添付

# 関連Issue

- Closes #84
