### PR TITLE
Issue #87: 大気質チャートの時刻補正

### DIFF
--- a/app/compare/page.tsx
+++ b/app/compare/page.tsx
@@ -365,6 +365,7 @@ export default function ComparePage() {
                   dataKey="pm2_5"
                   range="24h"
                   timeZone={leftAir24.data?.timezone ?? leftCity.timezone}
+                  utcOffsetSeconds={leftAir24.data?.utc_offset_seconds}
                 />
               </div>
             ) : (
@@ -486,6 +487,7 @@ export default function ComparePage() {
                   dataKey="pm2_5"
                   range="24h"
                   timeZone={rightAir24.data?.timezone ?? rightCity.timezone}
+                  utcOffsetSeconds={rightAir24.data?.utc_offset_seconds}
                 />
               </div>
             ) : (

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -258,6 +258,7 @@ export default function Home() {
                   dataKey="pm2_5"
                   range="24h"
                   timeZone={airQuery.data?.timezone ?? activeCity.timezone}
+                  utcOffsetSeconds={airQuery.data?.utc_offset_seconds}
                 />
               </div>
             ) : (

--- a/features/air-quality/ui/aq-chart-client.tsx
+++ b/features/air-quality/ui/aq-chart-client.tsx
@@ -11,6 +11,7 @@ import {
 } from "recharts";
 import type { AirQualityHourly } from "@/lib/types/air-quality";
 import { cn } from "@/lib/utils";
+import { toUtcDateFromLocalTime } from "@/lib/utils/timezone";
 
 type AQKey = "pm2_5" | "pm10" | "nitrogen_dioxide" | "ozone";
 
@@ -20,6 +21,7 @@ type AQChartProps = {
   range: "24h" | "5d";
   title?: string;
   timeZone?: string;
+  utcOffsetSeconds?: number;
   onRangeChange?: (range: "24h" | "5d") => void;
 };
 
@@ -32,9 +34,10 @@ function formatTimeLabel(
   value: string,
   range: "24h" | "5d",
   timeZone?: string,
+  utcOffsetSeconds?: number,
 ) {
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return value;
+  const date = toUtcDateFromLocalTime(value, utcOffsetSeconds);
+  if (!date || Number.isNaN(date.getTime())) return value;
 
   const options: Intl.DateTimeFormatOptions =
     range === "24h"
@@ -53,15 +56,16 @@ export function AQChart({
   range,
   title,
   timeZone,
+  utcOffsetSeconds,
   onRangeChange,
 }: AQChartProps) {
   const chartData = useMemo<ChartPoint[]>(() => {
     const values = data[dataKey];
     return data.time.map((time, index) => ({
-      time: formatTimeLabel(time, range, timeZone),
+      time: formatTimeLabel(time, range, timeZone, utcOffsetSeconds),
       value: values[index] ?? 0,
     }));
-  }, [data, dataKey, range, timeZone]);
+  }, [data, dataKey, range, timeZone, utcOffsetSeconds]);
 
   return (
     <div>

--- a/lib/domain/normalize-air-quality.ts
+++ b/lib/domain/normalize-air-quality.ts
@@ -57,6 +57,7 @@ export function normalizeAirQualityResponse(
     latitude: raw.latitude,
     longitude: raw.longitude,
     timezone: raw.timezone,
+    utc_offset_seconds: raw.utc_offset_seconds,
     hourly: normalizeHourly(raw.hourly),
   };
 }

--- a/lib/types/air-quality.ts
+++ b/lib/types/air-quality.ts
@@ -18,6 +18,7 @@ export type AirQualityResponse = {
   latitude: number;
   longitude: number;
   timezone: string;
+  utc_offset_seconds: number;
   hourly: AirQualityHourly;
 };
 
@@ -25,5 +26,6 @@ export type AirQualityResponseRaw = {
   latitude: number;
   longitude: number;
   timezone: string;
+  utc_offset_seconds: number;
   hourly: AirQualityHourlyRaw;
 };

--- a/lib/validators/air-quality.ts
+++ b/lib/validators/air-quality.ts
@@ -12,5 +12,6 @@ export const AirQualityResponseSchema = z.object({
   latitude: z.number(),
   longitude: z.number(),
   timezone: z.string(),
+  utc_offset_seconds: z.number(),
   hourly: AirQualityHourlySchema,
 });

--- a/tests/unit/domain/normalize-air-quality.test.ts
+++ b/tests/unit/domain/normalize-air-quality.test.ts
@@ -7,6 +7,7 @@ describe("normalizeAirQualityResponse", () => {
       latitude: 35.6,
       longitude: 139.6,
       timezone: "Asia/Tokyo",
+      utc_offset_seconds: 32400,
       hourly: {
         time: ["t0", "t1", "t2"],
         pm10: [10, 11, null],
@@ -27,6 +28,7 @@ describe("normalizeAirQualityResponse", () => {
       latitude: 35.6,
       longitude: 139.6,
       timezone: "Asia/Tokyo",
+      utc_offset_seconds: 32400,
       hourly: {
         time: ["t0", "t1", "t2", "t3"],
         pm10: [10, null, 12, 13],


### PR DESCRIPTION
# 概要

大気質チャートの時刻表示を `utc_offset_seconds` で補正し、都市タイムゾーンに整合させました。

# 背景・目的

- 海外都市で時刻ラベルが端末ローカル時間とズレるため

# 変更内容

- 大気質レスポンスに `utc_offset_seconds` を追加
- 正規化処理でオフセットを保持
- チャートの時刻ラベル生成を補正

# 影響範囲

- `lib/types/air-quality.ts`
- `lib/validators/air-quality.ts`
- `lib/domain/normalize-air-quality.ts`
- `features/air-quality/ui/aq-chart-client.tsx`
- `app/page.tsx`
- `app/compare/page.tsx`
- `tests/unit/domain/normalize-air-quality.test.ts`

# テスト

- [ ] 未実施（理由）:
- [ ] 手動:
- [x] 自動: `pnpm test` / `pnpm typecheck` (pre-push)

# スクリーンショット

- [x] 不要
- [ ] 添付

# 関連Issue

- Closes #87
